### PR TITLE
Makefile.am: fix parallel make errors with samples

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,31 +61,39 @@ endif
 bin_raw_identify_SOURCES = samples/raw-identify.cpp
 bin_raw_identify_CPPFLAGS = $(lib_libraw_a_CPPFLAGS)
 bin_raw_identify_LDADD = -Llib/  -lraw 
+bin_raw_identify_DEPENDENCIES = lib/libraw.a
 
 bin_unprocessed_raw_SOURCES = samples/unprocessed_raw.cpp
 bin_unprocessed_raw_CPPFLAGS = $(lib_libraw_a_CPPFLAGS)
 bin_unprocessed_raw_LDADD = -Llib/ -lraw
+bin_unprocessed_raw_DEPENDENCIES = lib/libraw.a
 
 bin_4channels_SOURCES = samples/4channels.cpp
 bin_4channels_CPPFLAGS = $(lib_libraw_a_CPPFLAGS)
 bin_4channels_LDADD = -Llib/ -lraw 
+bin_4channels_DEPENDENCIES = lib/libraw.a
 
 bin_simple_dcraw_SOURCES = samples/simple_dcraw.cpp
 bin_simple_dcraw_CPPFLAGS = $(lib_libraw_a_CPPFLAGS)
 bin_simple_dcraw_LDADD = -Llib/ -lraw
+bin_simple_dcraw_DEPENDENCIES = lib/libraw.a
 
 bin_mem_image_SOURCES = samples/mem_image.cpp
 bin_mem_image_CPPFLAGS = $(lib_libraw_a_CPPFLAGS)
 bin_mem_image_LDADD = -Llib/ -lraw 
+bin_mem_image_DEPENDENCIES = lib/libraw.a
 
 bin_dcraw_half_SOURCES = samples/dcraw_half.c
 bin_dcraw_half_CPPFLAGS = $(lib_libraw_a_CPPFLAGS)
 bin_dcraw_half_LDADD = -Llib/ -lraw 
+bin_dcraw_half_DEPENDENCIES = lib/libraw.a
 
 bin_half_mt_SOURCES = samples/half_mt.c
 bin_half_mt_CFLAGS = $(lib_libraw_r_a_CXXFLAGS)
 bin_half_mt_LDADD = -Llib/ -lraw_r 
+bin_half_mt_DEPENDENCIES = lib/libraw_r.a
 
 bin_dcraw_emu_SOURCES = samples/dcraw_emu.cpp
 bin_dcraw_emu_CPPFLAGS = $(lib_libraw_a_CPPFLAGS)
 bin_dcraw_emu_LDADD = -Llib/ -lraw 
+bin_dcraw_emu_DEPENDENCIES = lib/libraw.a


### PR DESCRIPTION
When building libraw using parallel make jobs with the configure option --enable-examples set, the compile process will often fail when compiling the examples due to the libraries not being built before they are needed.
