### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,6 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libraw.pc libraw_r.pc
 
 # Libraries
-lib_LIBRARIES = lib/libraw.a lib/libraw_r.a
 lib_LTLIBRARIES = lib/libraw.la lib/libraw_r.la
 
 lib_libraw_a_CPPFLAGS = -DLIBRAW_NOTHREADS -w


### PR DESCRIPTION
While I was packaging the 0.13.6 release I thought I could improve my previous patch a bit more. :)

The first commit that removes the lib_LIBRARIES line makes it so the related static libraries are only installed if --enable-static is set. Otherwise they are always installed even if --disable-static is passed to configure.

The second commit causes the sample builds to check the libtool archives for the correct dependencies so either the shared libraries or the static libraries are used depending on which are being built or used.
