### PR TITLE
Win32 compile fixes

### DIFF
--- a/libraw/libraw_datastream.h
+++ b/libraw/libraw_datastream.h
@@ -82,6 +82,7 @@ class DllDef LibRaw_abstract_datastream
     LibRaw_abstract_datastream *substream;
 };
 
+template class DllDef std::auto_ptr<std::streambuf>;
 class DllDef  LibRaw_file_datastream: public LibRaw_abstract_datastream
 {
   protected:


### PR DESCRIPTION
When building an external application against LibRaw I get following compiler warning with VS2010:

warning C4251: 'LibRaw_file_datastream::f' : class 'std::auto_ptr<_Ty>' needs to have dll-interface to be used by clients of class 'LibRaw_file_datastream'
1>          with
1>          [
1>              _Ty=std::streambuf
1>          ]

This patch fixes the warning.

Regards, Jens
