### PR TITLE
VS Makefile with optional OpenMP and LCMS support

### DIFF
--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -1,3 +1,5 @@
+# Additional compiler flags (OpenMP, SSEx, AVX, ...)
+#COPT=/openmp /arch:SSE2 /arch:AVX
 
 # Demosaic Pack GPL2:
 #CFLAGS_DP2=/I"..\\LibRaw-demosaic-pack-GPL2"
@@ -6,6 +8,14 @@
 # Demosaic Pack GPL3:
 #CFLAGS_DP3=/I"..\\LibRaw-demosaic-pack-GPL3"
 #CFLAGSG3=/DLIBRAW_DEMOSAIC_PACK_GPL3
+
+# LCMS 1.x support
+#LCMS_DEF=/DUSE_LCMS /DCMS_DLL /I..\lcms-1.19\include
+#LCMS_LIB=..\lcms-1.19\bin\lcms.lib
+
+# LCMS 2.x support
+#LCMS_DEF=/DUSE_LCMS2 /DCMS_DLL /I..\lcms2-2.3\include
+#LCMS_LIB=..\lcms2-2.3\bin\lcms2_dll.lib
 
 
 SAMPLES=bin\raw-identify.exe bin\simple_dcraw.exe  bin\dcraw_emu.exe bin\dcraw_half.exe bin\half_mt.exe bin\mem_image.exe bin\unprocessed_raw.exe bin\4channels.exe bin\multirender_test.exe bin\postprocessing_benchmark.exe
@@ -22,7 +32,7 @@ LIB_OBJECTS=object\dcraw_common_st.obj object\dcraw_fileio_st.obj  object\libraw
 DLL_OBJECTS=object\dcraw_common.obj object\dcraw_fileio.obj  object\libraw_cxx.obj object\libraw_datastream.obj object\libraw_c_api.obj  object\demosaic_packs.obj
 
 CC=cl.exe
-COPT=/EHsc /MT /I. /DWIN32 /O2 /W0 /nologo $(CFLAGSG2) $(CFLAGSG3)
+COPT=/EHsc /MP /MT /I. /DWIN32 /O2 /W0 /nologo $(COPT) $(CFLAGSG2) $(CFLAGSG3) $(LCMS_DEF) 
 
 LINKLIB=$(LIBDLL)
 
@@ -65,7 +75,7 @@ bin\half_mt.exe: $(LINKLIB) samples\half_mt_win32.c
 
 $(DLL): $(DLL_OBJECTS)
 	-del /f $(DLL) $(LIBDLL)
-	cl $(COPT) /LD $(DLL_OBJECTS) /link /out:"$(DLL)" /implib:"$(LIBDLL)"
+	cl $(COPT) /LD $(DLL_OBJECTS) $(LCMS_LIB) /link /out:"$(DLL)" /implib:"$(LIBDLL)"
 
 object\dcraw_common.obj: internal\dcraw_common.cpp
 	$(CC) $(COPT) /DLIBRAW_BUILDLIB /Fo"object\\dcraw_common.obj" /c internal\dcraw_common.cpp


### PR DESCRIPTION
Hi,

since I needed lcms support in Libraw, I updated the VS buildfile. Moreover the optional openmp flag was added, as it seem to be supported for Linux build files.

The configuration was tested with x64 lcms 1.19 and x64 lcms2.3(trunk), both with the lcms dynamically linked.

Cheers,
Daniel
