### PR TITLE
nmake additions

### DIFF
--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -1,5 +1,5 @@
 # Additional compiler flags (OpenMP, SSEx, AVX, ...)
-#COPT=/openmp /arch:SSE2 /arch:AVX
+#COPT_OPT=/openmp /arch:SSE2 /arch:AVX
 
 # Demosaic Pack GPL2:
 #CFLAGS_DP2=/I"..\\LibRaw-demosaic-pack-GPL2"
@@ -32,7 +32,7 @@ LIB_OBJECTS=object\dcraw_common_st.obj object\dcraw_fileio_st.obj  object\libraw
 DLL_OBJECTS=object\dcraw_common.obj object\dcraw_fileio.obj  object\libraw_cxx.obj object\libraw_datastream.obj object\libraw_c_api.obj  object\demosaic_packs.obj
 
 CC=cl.exe
-COPT=/EHsc /MP /MT /I. /DWIN32 /O2 /W0 /nologo $(COPT) $(CFLAGSG2) $(CFLAGSG3) $(LCMS_DEF) 
+COPT=/EHsc /MP /MT /I. /DWIN32 /O2 /W0 /nologo $(COPT_OPT) $(CFLAGSG2) $(CFLAGSG3) $(LCMS_DEF) 
 
 LINKLIB=$(LIBDLL)
 


### PR DESCRIPTION
Hi,
nmake seemed to have problems when values are passed via macrodefs (nmake @somefile) and the variables had the same name as used in the buildfile.
