### PR TITLE
LibRaw+Lcms2 compile problem

### DIFF
--- a/dcraw/dcraw.c
+++ b/dcraw/dcraw.c
@@ -9230,7 +9230,9 @@ void CLASS apply_profile (const char *input, const char *output)
   FILE *fp;
   unsigned size;
 
+#ifndef USE_LCMS2
   cmsErrorAction (LCMS_ERROR_SHOW);
+#endif
   if (strcmp (input, "embed"))
     hInProfile = cmsOpenProfileFromFile (input, "r");
   else if (profile_length) {

--- a/internal/dcraw_fileio.cpp
+++ b/internal/dcraw_fileio.cpp
@@ -164,7 +164,9 @@ void CLASS apply_profile (const char *input, const char *output)
   FILE *fp;
   unsigned size;
 
+#ifndef USE_LCMS2
   cmsErrorAction (LCMS_ERROR_SHOW);
+#endif
   if (strcmp (input, "embed"))
     hInProfile = cmsOpenProfileFromFile (input, "r");
   else if (profile_length) {


### PR DESCRIPTION
Hi,

this should fix some compile errors, when trying to include lcms2 support.

Moreover I'm asking to cherry pick my previous commit 17238b3f3acb27126d18321046c0f9eaa816b174 from the 0.14.7 branch to the master. I guess that 0.14.7 branch won't never be merged completely into the master again.

Finally some question: I had to add /NODEFAULTLIB:LIBCMTD.lib to the linker, in order to compile the alpha2 with lcms2 and demosaicing. If I didnt', I got duplicate defined symbols during the linking. Can you confirm this?

Thanks,

Daniel Kaneider
