### PR TITLE
specify correct library to link against for libraw_r pkgconfig file

### DIFF
--- a/libraw_r.pc.in
+++ b/libraw_r.pc.in
@@ -7,5 +7,5 @@ Name: libraw
 Description: Raw image decoder library (thread-safe)
 Requires: @PACKAGE_REQUIRES@
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
+Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
 Cflags: -I${includedir}/libraw


### PR DESCRIPTION
Currently the libraw_r pkgconfig file specifies the standard libraw library when it should probably specify the libraw_r library instead.
