### PR TITLE
Update dcraw_common.cpp

### DIFF
--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -7118,7 +7118,7 @@ void CLASS adobe_coeff (const char *t_make, const char *t_model)
       if (table[i].t_black)   black   = (ushort) table[i].t_black;
       if (table[i].t_maximum) maximum = (ushort) table[i].t_maximum;
       if (table[i].trans[0]) {
-	for (j=0; j < 12; j++)
+	for (j=0; j < 3; j++)
 #ifdef LIBRAW_LIBRARY_BUILD
           imgdata.color.cam_xyz[0][j] = 
 #endif


### PR DESCRIPTION
The adobe_coeff function has a bug where the color values are written to out of bounds of the cam_xyz array. The array is declared as cam_xyz[4][3] whereas the inner for loop is looping through indexes 0 to 11 (the j variable). This variable is then used to set the value in cam_xyz[0][j] where j > 2 meaning out of bounds.
