### PR TITLE
fix compile error in VS 2012

### DIFF
--- a/internal/dht_demosaic.cpp
+++ b/internal/dht_demosaic.cpp
@@ -812,14 +812,14 @@ void DHT::make_rbhv(int i) {
 
 void DHT::make_rb() {
 #if defined(LIBRAW_USE_OPENMP)
-#pragma omp barier
+#pragma omp barrier
 #pragma omp parallel for schedule(guided)
 #endif
 	for (int i = 0; i < libraw.imgdata.sizes.iheight; ++i) {
 		make_rbdiag(i);
 	}
 #if defined(LIBRAW_USE_OPENMP)
-#pragma omp barier
+#pragma omp barrier
 #pragma omp parallel for schedule(guided)
 #endif
 	for (int i = 0; i < libraw.imgdata.sizes.iheight; ++i) {


### PR DESCRIPTION
change 'barier' in line 815, 822 to 'barrier'
