### PR TITLE
Fix libdirs and include paths in pkgconfig files

### DIFF
--- a/cmake/data/libraw.pc.cmake
+++ b/cmake/data/libraw.pc.cmake
@@ -9,4 +9,4 @@ URL: http://www.libraw.org
 Requires:
 Version: @RAW_LIB_VERSION_STRING@
 Libs: -L${libdir} -lraw
-Cflags: -I${includedir}/libraw
+Cflags: -I${includedir}

--- a/cmake/data/libraw_r.pc.cmake
+++ b/cmake/data/libraw_r.pc.cmake
@@ -9,4 +9,4 @@ URL: http://www.libraw.org
 Requires:
 Version: @RAW_LIB_VERSION_STRING@
 Libs: -L${libdir} -lraw_r
-Cflags: -I${includedir}/libraw
+Cflags: -I${includedir}


### PR DESCRIPTION
Hi, here's two commits that 
- make sure the pkgconfig files also respect LIB_SUFFIX
- remove the doubled "libraw" from the include dir path

With the LIB_SUFFIX patch (already in master) plus these changes all reverse deps of libraw in gentoo compile fine with 0.16_beta2. Please pull!
