### PR TITLE
Remove configure dependency on nonstandard echo -n

### DIFF
--- a/shlib-version.sh
+++ b/shlib-version.sh
@@ -6,6 +6,6 @@ major=`grep LIBRAW_SHLIB_CURRENT $vfile |head -1 | awk '{print $3}'`
 minor=`grep LIBRAW_SHLIB_REVISION $vfile | head -1 | awk '{print $3}'`
 patch=`grep LIBRAW_SHLIB_AGE $vfile | head -1 | awk '{print $3}'`
 
-printf "$major:$minor:$patch"
+echo "$major:$minor:$patch" | awk '{printf $1}'
 
 

--- a/version.sh
+++ b/version.sh
@@ -8,9 +8,9 @@ patch=`grep LIBRAW_PATCH_VERSION $vfile | head -1 | awk '{print $3}'`
 tail=`grep LIBRAW_VERSION_TAIL $vfile | head -1 | awk '{print $3}'`
 
 if [ x$tail = xRelease ] ; then
- printf "$major.$minor.$patch"
+ echo "$major.$minor.$patch" | awk '{printf $1}'
 else
- printf "$major.$minor.$patch-$tail"
+ echo "$major.$minor.$patch-$tail" | awk '{printf $1}'
 fi
 
 


### PR DESCRIPTION
Hello!

LibRaw wasn't building properly on Mac OS X 10.10.1. This fix allows a proper "configure" file to be generated.

Errors fixed with this fix:

```
LibRaw p$ autoreconf
configure.ac:2: warning: AC_INIT: not a literal: -n 0.17.0-PreAlpha
configure.ac:2: warning: AC_INIT: not a literal: -n 0.17.0-PreAlpha
configure.ac:2: warning: AC_INIT: not a literal: -n 0.17.0-PreAlpha
configure.ac:2: warning: AC_INIT: not a literal: -n 0.17.0-PreAlpha
configure.ac:9: error: required file './compile' not found
configure.ac:9:   'automake --add-missing' can install 'compile'
...
LibRaw p$ ./configure
./configure: line 4: .: filename argument required
.: usage: . filename [arguments]
LibRaw p$ 
```

/bin/sh has the following behavior:

``` sh
sh-3.2$ echo -n Please dont print a newline
-n Please dont print a newline
sh-3.2$
```

printf is a more standard command for controlling the printing of the newline.
