### PR TITLE
Fix initialization order

### DIFF
--- a/src/libraw_datastream.cpp
+++ b/src/libraw_datastream.cpp
@@ -64,10 +64,11 @@ LibRaw_file_datastream::~LibRaw_file_datastream()
 
 LibRaw_file_datastream::LibRaw_file_datastream(const char *fname)
     :filename(fname)
+    ,_fsize(0)
 #ifdef WIN32
     ,wfilename()
 #endif
-    ,jas_file(NULL),_fsize(0)
+    ,jas_file(NULL)
 {
   if (filename.size()>0) 
     {


### PR DESCRIPTION
Clang warns "field 'jas_file' will be initialized after field '_fsize'"