### PR TITLE
libraw_x3f.cpp: remove Byte order mark

### DIFF
--- a/internal/libraw_x3f.cpp
+++ b/internal/libraw_x3f.cpp
@@ -1,4 +1,4 @@
-﻿/* Library for accessing X3F Files 
+/* Library for accessing X3F Files 
 ----------------------------------------------------------------
 BSD-style License
 ----------------------------------------------------------------


### PR DESCRIPTION
The U+FEFF character, which is a Byte order mark, at the beginning of
libraw_x3f.cpp, prevents gcc 4.3.x from building this file:

src/../internal/libraw_x3f.cpp:1: error: stray '\357' in program
src/../internal/libraw_x3f.cpp:1: error: stray '\273' in program
src/../internal/libraw_x3f.cpp:1: error: stray '\277' in program

Support in gcc for the Byte order mark has been added in gcc
4.4.x. Since anyway this Byte order mark is not useful, we simply
remove it.

See https://en.wikipedia.org/wiki/Byte_order_mark for more details.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>