### PR TITLE
initialize the arrays

### DIFF
--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -13319,6 +13319,8 @@ void CLASS identify()
   memset (cblack, 0, sizeof cblack);
   memset (white, 0, sizeof white);
   memset (mask, 0, sizeof mask);
+  memset (make, 0, sizeof make);
+  memset (model, 0, sizeof model);
   thumb_offset = thumb_length = thumb_width = thumb_height = 0;
   load_raw = thumb_load_raw = 0;
   write_thumb = &CLASS jpeg_thumb;


### PR DESCRIPTION
How about initializing these arrays in dcraw_common.cpp:
make, model

They are used in strlen() and probably will cause an issue in case of null-terminator absence (please check).