### PR TITLE
fixed undefined behavior

### DIFF
--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -93,6 +93,13 @@ int my_strlen(const char *str)
 }
 #define strlen(a) my_strlen((a))
 
+template <typename T, size_t  N>
+static void remove_trailing_spaces(T (&str) [N]) {
+	if(!N) return;
+	str[N - 1] = '\0'; // force null-terminate, in case of not
+	for (size_t i(N - 2); (i >= 0) && (str[i] == ' '); --i) {str[i] = '\0';} ///* Remove trailing spaces */
+}
+
 ushort CLASS sget2 (uchar *s)
 {
   if (order == 0x4949)		/* "II" means little-endian */
@@ -13602,10 +13609,12 @@ void CLASS identify()
      *cp = 0;
   if (!strncasecmp(model,"PENTAX",6))
     strcpy (make, "Pentax");
-  cp = make + strlen(make);		/* Remove trailing spaces */
-  while (*--cp == ' ') *cp = 0;
-  cp = model + strlen(model);
-  while (*--cp == ' ') *cp = 0;
+  //cp = make + strlen(make);		/* Remove trailing spaces */
+  //while (*--cp == ' ') *cp = 0;
+  remove_trailing_spaces(make); //fixed undefined behavior
+  //cp = model + strlen(model);
+  //while (*--cp == ' ') *cp = 0;
+  remove_trailing_spaces(model); //fixed undefined behavior
   i = strlen(make);			/* Remove make from model */
   if (!strncasecmp (model, make, i) && model[i++] == ' ')
     memmove (model, model+i, 64-i);


### PR DESCRIPTION
Hello,
I have numerous crash reports from Android users. Something like this (but the line is same in all reports: **while (*--cp == ' ') *cp = 0**):
```
********** Crash dump: **********
Build fingerprint: 'samsung/klimtwifixx/klimtwifi:5.0.2/LRX22G/T700XXU1BOK1:user/release-keys'
pid: 23228, tid: 23526, name: fifo-pool-threa  >>> com.anthonymandra.rawdroidpro <<<
signal 11 (SIGSEGV), code 0 (SI_USER), fault addr 0x202640b6
Stack frame #00 pc 0004f296  /data/app/com.anthonymandra.rawdroidpro-2/lib/arm/librawprocessor.so (LibRaw::identify()+1453): Routine LibRaw::identify() at D:\proj\rawdroid\rawprocessor\jni/D:/proj/rawdroid/rawprocessor/jni/raw/LibRaw/internal/dcraw_common.cpp:13604 (discriminator 4)
Stack frame #01 pc 00025df9  /data/app/com.anthonymandra.rawdroidpro-2/lib/arm/librawprocessor.so (LibRaw::open_datastream(LibRaw_abstract_datastream*)+80): Routine LibRaw::open_datastream(LibRaw_abstract_datastream*) at D:\proj\rawdroid\rawprocessor\jni/D:/proj/rawdroid/rawprocessor/jni/raw/LibRaw/src/libraw_cxx.cpp:1683
Stack frame #02 pc 0001e5d7  /data/app/com.anthonymandra.rawdroidpro-2/lib/arm/librawprocessor.so (Java_com_anthonymandra_rawprocessor_LibRaw_getThumbFd+54): Routine Java_com_anthonymandra_rawprocessor_LibRaw_getThumbFd at D:\proj\rawdroid\rawprocessor\jni/D:/proj/rawdroid/rawprocessor/jni/rawprocessor/rawprocessor.cpp:120
```
after my commit the issue was fixed.

sometimes (on some cases), string _make_ loses null-terminator (and strlen() causes segfault):

``cp = make + strlen(make);``

also, this code will cause an issue if string length is 0 (look at decrement):

`while (*--cp == ' ') *cp = 0;`

I am not sure, whether my commit is absolutely brilliant, but I had to propose it =)

I guess you should carefully test it before merge.

Thanks in advance.


