### PR TITLE
Added space before DCRAW_VERSION to prevent MS VS compiler errors

### DIFF
--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -14907,7 +14907,7 @@ void CLASS tiff_head (struct tiff_hdr *th, int full)
   strncpy (th->t_desc, desc, 512);
   strncpy (th->t_make, make, 64);
   strncpy (th->t_model, model, 64);
-  strcpy (th->soft, "dcraw v "DCRAW_VERSION);
+  strcpy (th->soft, "dcraw v " DCRAW_VERSION);
   t = localtime (&timestamp);
   sprintf (th->date, "%04d:%02d:%02d %02d:%02d:%02d",
       t->tm_year+1900,t->tm_mon+1,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);


### PR DESCRIPTION
Without the space, the following compiler error occurs in Visual Studio (confirmed with 2013 and 2015; 2008 worked fine).

1>D:\[..]\src\FreeImage\Source\LibRawLite\internal\dcraw_common.cpp(14590): error C3688: invalid literal suffix 'DCRAW_VERSION'; literal operator or literal operator template 'operator ""DCRAW_VERSION' not found
1>D:\[..]\src\FreeImage\Source\LibRawLite\internal\dcraw_common.cpp(14590): error C2660: 'strcpy': function does not take 1 arguments

Please ignore the different code line numbers, since the build output is from LibRaw 0.18.0.201511