### PR TITLE
Support -output option for dcraw_emu

### DIFF
--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -478,7 +478,6 @@ typedef struct
   char *camera_profile;  /* -p */
   char *bad_pixels;      /* -P */
   char *dark_frame;      /* -K */
-  char *outfn;           /* -output */
   int output_bps;        /* -4 */
   int output_tiff;       /* -T */
   int user_flip;         /* -t */

--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -478,6 +478,7 @@ typedef struct
   char *camera_profile;  /* -p */
   char *bad_pixels;      /* -P */
   char *dark_frame;      /* -K */
+  char *outfn;           /* -output */
   int output_bps;        /* -4 */
   int output_tiff;       /* -T */
   int user_flip;         /* -t */

--- a/samples/dcraw_emu.cpp
+++ b/samples/dcraw_emu.cpp
@@ -191,6 +191,7 @@ int main(int argc, char *argv[])
   int i, arg, c, ret;
   char opm, opt, *cp, *sp;
   int use_bigfile = 0, use_timing = 0, use_mem = 0;
+  char outfn[1024];
 #ifdef USE_DNGSDK
   dng_host *dnghost = NULL;
 #endif
@@ -301,7 +302,7 @@ int main(int argc, char *argv[])
       break;
     case 'o':
       if(!strcmp(optstr,"-output"))
-        OUT.outfn = argv[arg++];
+        strcpy(outfn, argv[arg++]);
       else if(isdigit(argv[arg][0]) && !isdigit(argv[arg][1]))
         OUT.output_color = atoi(argv[arg++]);
 #ifndef NO_LCMS
@@ -479,8 +480,6 @@ int main(int argc, char *argv[])
 
   for (; arg < argc; arg++)
   {
-    char outfn[1024];
-
     if (verbosity)
       printf("Processing file %s\n", argv[arg]);
 
@@ -595,10 +594,8 @@ int main(int argc, char *argv[])
     if (use_timing)
       timerprint("LibRaw::dcraw_process()", argv[arg]);
 
-    if(OUT.outfn)
-      strcpy(outfn, OUT.outfn);
-    else
-      snprintf(outfn, sizeof(outfn), "%s.%s", argv[arg], OUT.output_tiff ? "tiff" : (P1.colors > 1 ? "ppm" : "pgm"));
+    if(strlen(outfn) == 0)
+       snprintf(outfn, sizeof(outfn), "%s.%s", argv[arg], OUT.output_tiff ? "tiff" : (P1.colors>1?"ppm":"pgm"));
 
     if (verbosity)
     {

--- a/samples/dcraw_emu.cpp
+++ b/samples/dcraw_emu.cpp
@@ -99,6 +99,7 @@ void usage(const char *prog)
          "-G        Use green_matching() filter\n"
          "-B <x y w h> use cropbox\n"
          "-F        Use FILE I/O instead of streambuf API\n"
+         "-output <file> Output file name\n"
          "-timing   Detailed timing report\n"
          "-fbdd N   0 - disable FBDD noise reduction (default), 1 - light FBDD, 2 - full\n"
          "-dcbi N   Number of extra DCD iterations (default - 0)\n"
@@ -109,7 +110,7 @@ void usage(const char *prog)
 #endif
 #ifdef LIBRAW_DEMOSAIC_PACK_GPL3
          //"-amazeca  Use AMaZE chromatic aberrations refine (only if q=10)\n"
-         "-acae <r b>Use chromatic aberrations correction\n" // modifJD
+         "-acae <r b> Use chromatic aberrations correction\n" // modifJD
          "-aline <l> reduction of line noise\n"
          "-aclean <l c> clean CFA\n"
          "-agreen <g> equilibrate green\n"
@@ -216,7 +217,7 @@ int main(int argc, char *argv[])
           fprintf(stderr, "Non-numeric argument to \"-%c\"\n", opt);
           return 1;
         }
-    if (!strchr("ftdeam", opt) && argv[arg - 1][2])
+    if (!strchr("ftdeamo", opt) && argv[arg - 1][2])
       fprintf(stderr, "Unknown option \"%s\".\n", argv[arg - 1]);
     switch (opt)
     {
@@ -299,7 +300,9 @@ int main(int argc, char *argv[])
       OUT.shot_select = abs(atoi(argv[arg++]));
       break;
     case 'o':
-      if (isdigit(argv[arg][0]) && !isdigit(argv[arg][1]))
+      if(!strcmp(optstr,"-output"))
+        OUT.outfn = argv[arg++];
+      else if(isdigit(argv[arg][0]) && !isdigit(argv[arg][1]))
         OUT.output_color = atoi(argv[arg++]);
 #ifndef NO_LCMS
       else
@@ -592,7 +595,10 @@ int main(int argc, char *argv[])
     if (use_timing)
       timerprint("LibRaw::dcraw_process()", argv[arg]);
 
-    snprintf(outfn, sizeof(outfn), "%s.%s", argv[arg], OUT.output_tiff ? "tiff" : (P1.colors > 1 ? "ppm" : "pgm"));
+    if(OUT.outfn)
+      strcpy(outfn, OUT.outfn);
+    else
+      snprintf(outfn, sizeof(outfn), "%s.%s", argv[arg], OUT.output_tiff ? "tiff" : (P1.colors > 1 ? "ppm" : "pgm"));
 
     if (verbosity)
     {

--- a/samples/dcraw_emu.cpp
+++ b/samples/dcraw_emu.cpp
@@ -56,7 +56,7 @@ void usage(const char *prog)
 {
   printf("dcraw_emu: almost complete dcraw emulator\n");
   printf("Usage:  %s [OPTION]... [FILE]...\n", prog);
-  printf("-c float-num       Set adjust maximum threshold (default 0.75)\n"
+  printf("-c float-num       Set adjust maximum threshold (default = 0.75)\n"
          "-v        Verbose: print progress messages (repeated -v will add verbosity)\n"
          "-w        Use camera white balance, if possible\n"
          "-a        Average the whole image for white balance\n"
@@ -99,10 +99,10 @@ void usage(const char *prog)
          "-G        Use green_matching() filter\n"
          "-B <x y w h> use cropbox\n"
          "-F        Use FILE I/O instead of streambuf API\n"
-         "-output <file> Output file name\n"
+         "-output <file> Output file name (default = inputfile.[tiff|ppm|pgm]\n"
          "-timing   Detailed timing report\n"
-         "-fbdd N   0 - disable FBDD noise reduction (default), 1 - light FBDD, 2 - full\n"
-         "-dcbi N   Number of extra DCD iterations (default - 0)\n"
+         "-fbdd N   0 - disable FBDD noise reduction, 1 - light FBDD, 2 - full (default = 0)\n"
+         "-dcbi N   Number of extra DCD iterations (default = 0)\n"
          "-dcbe     DCB color enhance\n"
 #ifdef LIBRAW_DEMOSAIC_PACK_GPL2
          "-eeci     EECI refine for mixed VCD/AHD (q=8)\n"


### PR DESCRIPTION
Add `-output` option to `dcraw_emu` to specify output filename.
Usage example:
```bash
dcraw_emu -output output.ppm input.cr2
```

Related to #102.