### PR TITLE
Fix compile on libjpeg 9.2

### DIFF
--- a/dcraw/dcraw.c
+++ b/dcraw/dcraw.c
@@ -3538,7 +3538,7 @@ void CLASS kodak_jpeg_load_raw()
   jpeg_create_decompress(&cinfo);
   jpeg_stdio_src(&cinfo, ifp);
   cinfo.src->fill_input_buffer = fill_input_buffer;
-  jpeg_read_header(&cinfo, TRUE);
+  jpeg_read_header(&cinfo, boolean(TRUE));
   jpeg_start_decompress(&cinfo);
   if ((cinfo.output_width != width) || (cinfo.output_height * 2 != height) || (cinfo.output_components != 3))
   {
@@ -3602,7 +3602,7 @@ void CLASS kodak_jpeg_load_raw()
   try
   {
     jpeg_mem_src(&cinfo, jpg_buf, data_size);
-    int rc = jpeg_read_header(&cinfo, TRUE);
+    int rc = jpeg_read_header(&cinfo, boolean(TRUE));
     if (rc != 1)
       throw LIBRAW_EXCEPTION_DECODE_JPEG;
 
@@ -3714,7 +3714,7 @@ void CLASS lossy_dng_load_raw()
 #else
     jpeg_stdio_src(&cinfo, ifp);
 #endif
-    jpeg_read_header(&cinfo, TRUE);
+    jpeg_read_header(&cinfo, boolean(TRUE));
     jpeg_start_decompress(&cinfo);
     buf = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE, cinfo.output_width * 3, 1);
 #ifdef LIBRAW_LIBRARY_BUILD

--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -3242,7 +3242,7 @@ void CLASS kodak_jpeg_load_raw()
   jpeg_create_decompress(&cinfo);
   jpeg_stdio_src(&cinfo, ifp);
   cinfo.src->fill_input_buffer = fill_input_buffer;
-  jpeg_read_header(&cinfo, TRUE);
+  jpeg_read_header(&cinfo, boolean(TRUE));
   jpeg_start_decompress(&cinfo);
   if ((cinfo.output_width != width) || (cinfo.output_height * 2 != height) || (cinfo.output_components != 3))
   {
@@ -3306,7 +3306,7 @@ void CLASS kodak_jpeg_load_raw()
   try
   {
     jpeg_mem_src(&cinfo, jpg_buf, data_size);
-    int rc = jpeg_read_header(&cinfo, TRUE);
+    int rc = jpeg_read_header(&cinfo, boolean(TRUE));
     if (rc != 1)
       throw LIBRAW_EXCEPTION_DECODE_JPEG;
 
@@ -3418,7 +3418,7 @@ void CLASS lossy_dng_load_raw()
 #else
     jpeg_stdio_src(&cinfo, ifp);
 #endif
-    jpeg_read_header(&cinfo, TRUE);
+    jpeg_read_header(&cinfo, boolean(TRUE));
     jpeg_start_decompress(&cinfo);
     buf = (*cinfo.mem->alloc_sarray)((j_common_ptr)&cinfo, JPOOL_IMAGE, cinfo.output_width * 3, 1);
 #ifdef LIBRAW_LIBRARY_BUILD

--- a/src/libraw_cxx.cpp
+++ b/src/libraw_cxx.cpp
@@ -4183,7 +4183,7 @@ int LibRaw::unpack_thumb(void)
           }
           jpeg_create_decompress(&cinfo);
           jpeg_mem_src(&cinfo, (unsigned char *)T.thumb, T.tlength);
-          int rc = jpeg_read_header(&cinfo, TRUE);
+          int rc = jpeg_read_header(&cinfo, boolean(TRUE));
           if (rc != 1)
             goto err2;
           T.tcolors = (cinfo.num_components > 0 && cinfo.num_components <= 3) ? cinfo.num_components : 3;


### PR DESCRIPTION
Compiling against libjpeg 9.2 gives this error (on Mac OS at least):

```
internal/dcraw_common.cpp:3245:16: error: no matching function for call to 'jpeg_read_header'
      int rc = jpeg_read_header(&cinfo, TRUE);
               ^~~~~~~~~~~~~~~~
/usr/local/include/jpeglib.h:1039:13: note: candidate function not viable: no known conversion from 'int' to 'boolean' for 2nd argument
```

This PR just fixes the error.
