### PR TITLE
Use `LIBRAW_UNSUFFICIENT_MEMORY` instead of `ENOMEM` for out of memory errors.

### DIFF
--- a/src/libraw_cxx.cpp
+++ b/src/libraw_cxx.cpp
@@ -3601,7 +3601,7 @@ libraw_processed_image_t *LibRaw::dcraw_make_mem_thumb(int *errcode)
     if (!ret)
     {
       if (errcode)
-        *errcode = ENOMEM;
+        *errcode = LIBRAW_UNSUFFICIENT_MEMORY;
       return NULL;
     }
 
@@ -3631,7 +3631,7 @@ libraw_processed_image_t *LibRaw::dcraw_make_mem_thumb(int *errcode)
     if (!ret)
     {
       if (errcode)
-        *errcode = ENOMEM;
+        *errcode = LIBRAW_UNSUFFICIENT_MEMORY;
       return NULL;
     }
 
@@ -3789,7 +3789,7 @@ libraw_processed_image_t *LibRaw::dcraw_make_mem_image(int *errcode)
   if (!ret)
   {
     if (errcode)
-      *errcode = ENOMEM;
+      *errcode = LIBRAW_UNSUFFICIENT_MEMORY;
     return NULL;
   }
   memset(ret, 0, sizeof(libraw_processed_image_t));


### PR DESCRIPTION
https://www.libraw.org/docs/API-CXX.html#dcraw_make_mem_image states the following:

> If caller has passed not-NULL value as errorcode parameter, than *errorcode will be set to error code according to error code convention.

But the error code is set to `ENOMEM` instead of `LIBRAW_UNSUFFICIENT_MEMORY`. This patch fixes that in several situations.