### PR TITLE
Typos

### DIFF
--- a/DEVELOPER-NOTES
+++ b/DEVELOPER-NOTES
@@ -34,7 +34,7 @@ If you wish to participate in LibRaw development please use GitHub fork.
      - removes .PSD files from doc/
      - removes itself
 
-3. Please do not use ./configure script in development enviroment.
+3. Please do not use ./configure script in development environment.
    This script generates Makefile from ./Makefile.in for use in production.
    The generated Makefile does not contain section to build internal/*
    from dcraw/dcraw.c

--- a/dcraw/dcraw.c
+++ b/dcraw/dcraw.c
@@ -5680,7 +5680,7 @@ void CLASS remove_zeroes()
 
 // @out FILEIO
 /*
-   Seach from the current directory up to the root looking for
+   Search from the current directory up to the root looking for
    a ".badpixels" file, and fix those pixels now.
  */
 void CLASS bad_pixels(const char *cfname)

--- a/doc/API-datastruct.html
+++ b/doc/API-datastruct.html
@@ -14,7 +14,7 @@
 <li><a href="#libraw_thumbnail_t"> Structure libraw_thumbnail_t: Description of Thumbnail </a></li>
 <li><a href="#libraw_lensinfo_t"> Structure libraw_lensinfo_t - lens data, extracted from EXIF/Makernotes </a></li>
 <li><a href="#libraw_output_params_t"> Structure libraw_output_params_t: Management of dcraw-Style Postprocessing </a> .</li>
-<li><a href="#libraw_processed_image_t"> Stucture libraw_processed_image_t - result set for dcraw_make_mem_image()/dcraw_make_mem_thumb() functions </a></li>
+<li><a href="#libraw_processed_image_t"> Structure libraw_processed_image_t - result set for dcraw_make_mem_image()/dcraw_make_mem_thumb() functions </a></li>
 </ol>
 </li>
 <li><a href="#datastream"> Input abstraction layer </a>
@@ -197,7 +197,7 @@
 <dt><strong> unsigned gpsdata[32]; </strong></dt>
 <dd>GPS data (unparsed block, to write to output as is).</dd>
 <dt><strong> libraw_gps_info_t parsed_gps; </strong></dt>
-<dd>Parsed GPS-data: longtitude/lattitude/altitude and time stamp.</dd>
+<dd>Parsed GPS-data: longtitude/latitude/altitude and time stamp.</dd>
 <dt><strong> char desc[512]; </strong></dt>
 <dd>Image description.</dd>
 <dt><strong> char artist[64]; </strong></dt>
@@ -466,7 +466,7 @@ Values 5-9 are useful only if "LibRaw demosaic pack GPL2" compiled in (see READM
 <dd>Decoder data format. See <a href="#decoder_flags"> list of LibRaw_decoder_flags </a> for details.</dd>
 </dl>
 <p><a name="libraw_processed_image_t"></a></p>
-<h3>Stucture libraw_processed_image_t - result set for dcraw_make_mem_image()/dcraw_make_mem_thumb() functions</h3>
+<h3>Structure libraw_processed_image_t - result set for dcraw_make_mem_image()/dcraw_make_mem_thumb() functions</h3>
 <p>Structure libraw_processed_image_t is produced by call of dcraw_make_mem_image()/dcraw_make_mem_thumb() and contains in-memory image of interpolated data or thumbnail. <br /> Data fields:</p>
 <dl>
 <dt><strong> LibRaw_image_formats type </strong></dt>
@@ -497,7 +497,7 @@ Values 5-9 are useful only if "LibRaw demosaic pack GPL2" compiled in (see READM
 </ul>
 <p>LibRaw user can create own datastream object derived from <a href="API-CXX.html#datastream"> LibRaw_abstract_datastream </a> . For example, such object may implement reading RAW data directly from camera (by remote interface). LibRaw can use these objects via <a href="API-CXX.html#open_datastream"> LibRaw::open_datastream() </a> interface.</p>
 <p>Datastreams can be used either via <a href="API-CXX.html#open_datastream"> LibRaw::open_datastream() </a> call (in this case datastream object should be created an maintained by user) or via <a href="API-CXX.html#open_file"> LibRaw::open_file() </a> and <a href="API-CXX.html#open_buffer"> LibRaw::open_buffer() </a> shortcuts.</p>
-<p>Only <a href="API-CXX.html"> C++ API </a> users may use object-oriented interface and implement own input interfaces. For <a href="API-C.html"> C API </a> users only built-on <strong> libraw_open_file()/libraw_open_buffer() </strong> shortcuts are avaliable.</p>
+<p>Only <a href="API-CXX.html"> C++ API </a> users may use object-oriented interface and implement own input interfaces. For <a href="API-C.html"> C API </a> users only built-on <strong> libraw_open_file()/libraw_open_buffer() </strong> shortcuts are available.</p>
 <p><a name="datastream_data"></a></p>
 <h3>Data fields</h3>
 <p>Definition:</p>

--- a/doc/Samples-LibRaw.html
+++ b/doc/Samples-LibRaw.html
@@ -146,7 +146,7 @@
  if( LIBRAW_SUCCESS != (ret = RawProcessor.dcraw_ppm_tiff_writer(outfn)))
  fprintf(stderr,"Cannot write %s: error %d\n",outfn,ret);
  }
- // we don't evoke recycle() or call the desctructor; C++ will do everything for us
+ // we don't evoke recycle() or call the destructor; C++ will do everything for us
  return 0;
 end:
  // got here after an error

--- a/internal/dcraw_fileio.cpp
+++ b/internal/dcraw_fileio.cpp
@@ -26,7 +26,7 @@ it under the terms of the one of two licenses as you choose:
 #include "internal/defines.h"
 #include "internal/var_defines.h"
 /*
-   Seach from the current directory up to the root looking for
+   Search from the current directory up to the root looking for
    a ".badpixels" file, and fix those pixels now.
  */
 void CLASS bad_pixels(const char *cfname)

--- a/internal/libraw_internal_funcs.h
+++ b/internal/libraw_internal_funcs.h
@@ -258,7 +258,7 @@ void        crw_init_tables (unsigned table, ushort *huff[2]);
     void        tiff_set(struct tiff_hdr *th, ushort *ntag,ushort tag, ushort type, int count, int val);
     void        tiff_head (struct tiff_hdr *th, int full);
 
-// splitted AHD code
+// split AHD code
 #define TS 512
     void        ahd_interpolate_green_h_and_v(int top, int left, ushort (*out_rgb)[TS][TS][3]);
     void ahd_interpolate_r_and_b_in_rgb_and_convert_to_cielab(int top, int left, ushort (*inout_rgb)[TS][3], short (*out_lab)[TS][3]);

--- a/samples/half_mt.c
+++ b/samples/half_mt.c
@@ -106,7 +106,7 @@ void usage(const char *p)
 {
   printf("%s: Multi-threaded LibRaw sample app. Emulates dcraw -h [-w] [-a]\n", p);
   printf("Options:\n"
-         "-J n  - set parrallel job coun (default 2)\n"
+         "-J n  - set parallel job count (default 2)\n"
          "-v    - verbose\n"
          "-w    - use camera white balance\n"
          "-a    - average image for white balance\n");

--- a/samples/half_mt_win32.c
+++ b/samples/half_mt_win32.c
@@ -123,7 +123,7 @@ int process_files(void *q)
 void usage(const char *p)
 {
   printf("Options:\n"
-         "-J n  - set parrallel job coun (default 2)\n"
+         "-J n  - set parallel job count (default 2)\n"
          "-v    - verbose\n"
          "-w    - use camera white balance\n"
          "-T    - output TIFF instead of PPM\n"

--- a/src/libraw_cxx.cpp
+++ b/src/libraw_cxx.cpp
@@ -4493,7 +4493,7 @@ void LibRaw::exp_bef(float shift, float smooth)
     C.data_maximum = lut[C.data_maximum];
   if (C.maximum <= TBLN)
     C.maximum = lut[C.maximum];
-  // no need to adjust the minumum, black is already subtracted
+  // no need to adjust the minimum, black is already subtracted
   free(lut);
 }
 


### PR DESCRIPTION
Some are  user-facing. Others are trivial source comments. Found using `codespell -q 3`