### PR TITLE
Put rogue printf's behind #ifdef DCRAW_VERBOSE

### DIFF
--- a/internal/aahd_demosaic.cpp
+++ b/internal/aahd_demosaic.cpp
@@ -691,7 +691,9 @@ AAHD::~AAHD() {
 }
 
 void LibRaw::aahd_interpolate() {
+#ifdef DCRAW_VERBOSE
 	printf("AAHD interpolating\n");
+#endif
 	AAHD aahd(*this);
 	aahd.hide_hots();
 	aahd.make_ahd_greens();

--- a/internal/dht_demosaic.cpp
+++ b/internal/dht_demosaic.cpp
@@ -855,7 +855,9 @@ DHT::~DHT() {
 }
 
 void LibRaw::dht_interpolate() {
+#ifdef DCRAW_VERBOSE
 	printf("DHT interpolating\n");
+#endif
 	DHT dht(*this);
 	dht.hide_hots();
 	dht.make_hv_dirs();


### PR DESCRIPTION
AAHD and DHT demosaicing are printing out messages to stdout. This patch moves the printouts behind `#ifdef DCRAW_VERBOSE`, which seems to be the standard practice in LibRaw.
