### PR TITLE
Allowing wide char on MSYS2

### DIFF
--- a/libraw/libraw.h
+++ b/libraw/libraw.h
@@ -48,7 +48,7 @@ extern "C"
   DllDef libraw_data_t *libraw_init(unsigned int flags);
   DllDef int libraw_open_file(libraw_data_t *, const char *);
   DllDef int libraw_open_file_ex(libraw_data_t *, const char *, INT64 max_buff_sz);
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef (_WIN32)
   DllDef int libraw_open_wfile(libraw_data_t *, const wchar_t *);
   DllDef int libraw_open_wfile_ex(libraw_data_t *, const wchar_t *, INT64 max_buff_sz);
 #endif

--- a/src/libraw_c_api.cpp
+++ b/src/libraw_c_api.cpp
@@ -99,7 +99,7 @@ extern "C"
     LibRaw *ip = (LibRaw *)lr->parent_class;
     return ip->open_file(file, sz);
   }
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef (_WIN32)
   int libraw_open_wfile(libraw_data_t *lr, const wchar_t *file)
   {
     if (!lr)


### PR DESCRIPTION
I propose this patch in order to use wide char functions in MSYS2 environments.
It looks like many libs I checked are just doing like this (libtiff, glib, ...)