### PR TITLE
Recognise _WIN32 macro as WIN32 equivalent

### DIFF
--- a/RawSpeed/rawspeed.win32-dll.patch
+++ b/RawSpeed/rawspeed.win32-dll.patch
@@ -167,7 +167,7 @@ index 0000000..c806451
 +#ifndef DLLDEF_H
 +#define DLLDEF_H
 +
-+#ifdef WIN32
++#if defined(WIN32) || defined(_WIN32)
 +#ifdef _MSC_VER
 +#pragma warning( disable: 4251 )
 +#endif

--- a/dcraw/dcraw.c
+++ b/dcraw/dcraw.c
@@ -65,7 +65,7 @@
 #ifdef __CYGWIN__
 #include <io.h>
 #endif
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
 #include <sys/utime.h>
 #include <winsock2.h>
 #pragma comment(lib, "ws2_32.lib")
@@ -5985,7 +5985,7 @@ void CLASS bad_pixels(const char *cfname)
       if (errno != ERANGE)
         return;
     }
-#if defined(WIN32) || defined(DJGPP)
+#if defined(WIN32) || defined(_WIN32) || defined(DJGPP)
     if (fname[1] == ':')
       memmove(fname, fname + 2, len - 2);
     for (cp = fname; *cp; cp++)
@@ -14234,7 +14234,7 @@ void CLASS parse_exif(int base)
            l = pos2 - pos;
            memcpy(ccms, pos, l);
            ccms[l] = '\0';
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
            // Win32 strtok is already thread-safe
           pos = strtok(ccms, ",");
 #else
@@ -14247,7 +14247,7 @@ void CLASS parse_exif(int base)
               for (c = 0; c < 3; c++) {
                 imgdata.color.ccm[l][c] = (float)atoi(pos);
                 num += imgdata.color.ccm[l][c];
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
                 pos = strtok(NULL, ",");
 #else
                 pos = strtok_r(NULL, ",",&last);
@@ -23255,7 +23255,7 @@ int CLASS main(int argc, const char **argv)
       fprintf(stderr, _("Will not write an image to the terminal!\n"));
       return 1;
     }
-#if defined(WIN32) || defined(DJGPP) || defined(__CYGWIN__)
+#if defined(WIN32) || defined(_WIN32) || defined(DJGPP) || defined(__CYGWIN__)
     if (setmode(1, O_BINARY) < 0)
     {
       perror("setmode()");

--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -12899,7 +12899,7 @@ void CLASS parse_exif(int base)
            l = pos2 - pos;
            memcpy(ccms, pos, l);
            ccms[l] = '\0';
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
            // Win32 strtok is already thread-safe
           pos = strtok(ccms, ",");
 #else
@@ -12912,7 +12912,7 @@ void CLASS parse_exif(int base)
               for (c = 0; c < 3; c++) {
                 imgdata.color.ccm[l][c] = (float)atoi(pos);
                 num += imgdata.color.ccm[l][c];
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
                 pos = strtok(NULL, ",");
 #else
                 pos = strtok_r(NULL, ",",&last);

--- a/internal/defines.h
+++ b/internal/defines.h
@@ -45,7 +45,7 @@ it under the terms of the one of two licenses as you choose:
 #ifdef __CYGWIN__
 #include <io.h>
 #endif
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
 #include <sys/utime.h>
 #include <winsock2.h>
 #pragma comment(lib, "ws2_32.lib")

--- a/internal/dht_demosaic.cpp
+++ b/internal/dht_demosaic.cpp
@@ -344,7 +344,7 @@ void DHT::hide_hots() {
 void DHT::restore_hots() {
 	int iwidth = libraw.imgdata.sizes.iwidth;
 #if defined(LIBRAW_USE_OPENMP)
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #pragma omp parallel for firstprivate(iwidth)
 #else
 #pragma omp parallel for schedule(guided) firstprivate(iwidth) collapse(2)
@@ -831,7 +831,7 @@ void DHT::make_rb() {
 void DHT::copy_to_image() {
 	int iwidth = libraw.imgdata.sizes.iwidth;
 #if defined(LIBRAW_USE_OPENMP)
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #pragma omp parallel for
 #else
 #pragma omp parallel for schedule(guided) collapse(2)

--- a/libraw/libraw_datastream.h
+++ b/libraw/libraw_datastream.h
@@ -27,7 +27,7 @@ it under the terms of the one of two licenses as you choose:
 #ifndef __cplusplus
 
 #else /* __cplusplus */
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
 #include <winsock2.h>
 #endif
 /* No unique_ptr on Apple ?? */
@@ -45,7 +45,7 @@ it under the terms of the one of two licenses as you choose:
 #include <fstream>
 #include <memory>
 
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
 
 /* MSVS 2008 and above... */
 #if _MSC_VER >= 1500
@@ -55,7 +55,7 @@ it under the terms of the one of two licenses as you choose:
 
 #ifdef USE_DNGSDK
 
-#if defined WIN32 || defined(__MINGW32__)
+#if defined(WIN32) || defined(_WIN32) || defined(__MINGW32__)
 #define qWinOS 1
 #define qMacOS 0
 #elif defined(__APPLE__)
@@ -120,7 +120,7 @@ protected:
   LibRaw_abstract_datastream *substream;
 };
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #ifdef LIBRAW_USE_AUTOPTR
 template class DllDef std::auto_ptr<std::streambuf>;
 #else
@@ -140,7 +140,7 @@ protected:
 #endif
   std::string filename;
   INT64 _fsize;
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
   std::wstring wfilename;
 #endif
   FILE *jas_file;
@@ -244,12 +244,12 @@ protected:
   FILE *f, *sav;
   std::string filename;
   INT64 _fsize;
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
   std::wstring wfilename;
 #endif
 };
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 class DllDef LibRaw_windows_datastream : public LibRaw_buffer_datastream
 {
 public:

--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -21,7 +21,7 @@ it under the terms of the one of two licenses as you choose:
 #define _LIBRAW_TYPES_H
 
 #include <sys/types.h>
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 #include <sys/time.h>
 #endif
 
@@ -47,7 +47,7 @@ typedef unsigned __int64 uint64_t;
 
 #if defined(_OPENMP)
 
-#if defined(WIN32)
+#if defined(WIN32) || defined(_WIN32)
 #if defined(_MSC_VER) && (_MSC_VER >= 1600 || (_MSC_VER == 1500 && _MSC_FULL_VER >= 150030729))
 /* VS2010+ : OpenMP works OK, VS2008: have tested by cgilles */
 #define LIBRAW_USE_OPENMP
@@ -85,7 +85,7 @@ extern "C"
 #include "libraw_const.h"
 #include "libraw_version.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
   typedef __int64 INT64;
   typedef unsigned __int64 UINT64;
 #else
@@ -96,7 +96,7 @@ typedef unsigned long long UINT64;
   typedef unsigned char uchar;
   typedef unsigned short ushort;
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #ifdef LIBRAW_NODLL
 #define DllDef
 #else

--- a/samples/4channels.cpp
+++ b/samples/4channels.cpp
@@ -21,7 +21,7 @@ it under the terms of the one of two licenses as you choose:
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 #include <netinet/in.h>
 #else
 #include <winsock2.h>
@@ -29,7 +29,7 @@ it under the terms of the one of two licenses as you choose:
 
 #include "libraw/libraw.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #endif
 

--- a/samples/dcraw_emu.cpp
+++ b/samples/dcraw_emu.cpp
@@ -17,7 +17,7 @@ it under the terms of the one of two licenses as you choose:
 
 
  */
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 // suppress sprintf-related warning. sprintf() is permitted in sample code
 #define _CRT_SECURE_NO_WARNINGS
 #endif
@@ -27,7 +27,7 @@ it under the terms of the one of two licenses as you choose:
 #include <stdlib.h>
 #include <math.h>
 #include <ctype.h>
-#ifndef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -38,7 +38,7 @@ it under the terms of the one of two licenses as you choose:
 #include <sys/stat.h>
 
 #include "libraw/libraw.h"
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #include <windows.h>
 #else
@@ -106,7 +106,7 @@ void usage(const char *prog)
          "-aexpo <e p> exposure correction\n"
          "-apentax4shot enables merge of 4-shot pentax files\n"
          "-apentax4shotorder 3102 sets pentax 4-shot alignment order\n"
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
          "-mmap     Use mmap()-ed buffer instead of plain FILE I/O\n"
 #endif
          "-mem	   Use memory buffer instead of FILE I/O\n"
@@ -143,7 +143,7 @@ int my_progress_callback(void *d, enum LibRaw_progress p, int iteration, int exp
 }
 
 // timer
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 static struct timeval start, end;
 void timerstart(void) { gettimeofday(&start, NULL); }
 void timerprint(const char *msg, const char *filename)
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
 #ifdef USE_DNGSDK
   dng_host *dnghost = NULL;
 #endif
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
   int msize = 0, use_mmap = 0;
 #endif
   void *iobuffer = 0;
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
       OUT.user_qual = atoi(argv[arg++]);
       break;
     case 'm':
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
       if (!strcmp(optstr, "-mmap"))
         use_mmap = 1;
       else
@@ -401,7 +401,7 @@ int main(int argc, char *argv[])
       return 1;
     }
   }
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
   putenv((char *)"TZ=UTC"); // dcraw compatibility, affects TIFF datestamp field
 #else
   _putenv((char *)"TZ=UTC"); // dcraw compatibility, affects TIFF datestamp field
@@ -431,7 +431,7 @@ int main(int argc, char *argv[])
 
     timerstart();
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
     if (use_mmap)
     {
       int file = open(argv[arg], O_RDONLY);
@@ -575,7 +575,7 @@ int main(int argc, char *argv[])
     if (LIBRAW_SUCCESS != (ret = RawProcessor.dcraw_ppm_tiff_writer(outfn)))
       fprintf(stderr, "Cannot write %s: %s\n", outfn, libraw_strerror(ret));
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
     if (use_mmap && iobuffer)
     {
       munmap(iobuffer, msize);

--- a/samples/half_mt_win32.c
+++ b/samples/half_mt_win32.c
@@ -24,7 +24,7 @@ it under the terms of the one of two licenses as you choose:
 #include <windows.h>
 #include "libraw/libraw.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #endif
 

--- a/samples/mem_image.cpp
+++ b/samples/mem_image.cpp
@@ -22,7 +22,7 @@ it under the terms of the one of two licenses as you choose:
 
 #include "libraw/libraw.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #include <winsock2.h>
 #pragma comment(lib, "ws2_32.lib")

--- a/samples/multirender_test.cpp
+++ b/samples/multirender_test.cpp
@@ -20,7 +20,7 @@ it under the terms of the one of two licenses as you choose:
 #include <string.h>
 #include <math.h>
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -29,7 +29,7 @@ it under the terms of the one of two licenses as you choose:
 
 #include "libraw/libraw.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #endif
 

--- a/samples/openbayer_sample.cpp
+++ b/samples/openbayer_sample.cpp
@@ -20,7 +20,7 @@ it under the terms of the one of two licenses as you choose:
 #include <string.h>
 #include <math.h>
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/samples/postprocessing_benchmark.cpp
+++ b/samples/postprocessing_benchmark.cpp
@@ -19,7 +19,7 @@ it under the terms of the one of two licenses as you choose:
 #include <string.h>
 #include <math.h>
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
   return 0;
 }
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 static struct timeval start, end;
 void timerstart(void) { gettimeofday(&start, NULL); }
 float timerend(void)

--- a/samples/raw-identify.cpp
+++ b/samples/raw-identify.cpp
@@ -25,7 +25,7 @@ it under the terms of the one of two licenses as you choose:
 
 #include "libraw/libraw.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #define strcasecmp stricmp
 #define strncasecmp strnicmp

--- a/samples/simple_dcraw.cpp
+++ b/samples/simple_dcraw.cpp
@@ -20,7 +20,7 @@ it under the terms of the one of two licenses as you choose:
 #include <string.h>
 #include <math.h>
 
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -29,7 +29,7 @@ it under the terms of the one of two licenses as you choose:
 
 #include "libraw/libraw.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #endif
 

--- a/samples/unprocessed_raw.cpp
+++ b/samples/unprocessed_raw.cpp
@@ -21,7 +21,7 @@ it under the terms of the one of two licenses as you choose:
 #include <string.h>
 #include <math.h>
 #include <time.h>
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
 #include <netinet/in.h>
 #else
 #include <sys/utime.h>
@@ -30,7 +30,7 @@ it under the terms of the one of two licenses as you choose:
 
 #include "libraw/libraw.h"
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #define snprintf _snprintf
 #endif
 

--- a/src/libraw_cxx.cpp
+++ b/src/libraw_cxx.cpp
@@ -1064,7 +1064,7 @@ void LibRaw::merror(void *ptr, const char *where)
 
 int LibRaw::open_file(const char *fname, INT64 max_buf_size)
 {
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
   struct stat st;
   if (stat(fname, &st))
     return LIBRAW_IO_ERROR;
@@ -2536,7 +2536,7 @@ void LibRaw::fix_after_rawspeed(int) {}
 
 void LibRaw::clearCancelFlag()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
   InterlockedExchange(&_exitflag, 0);
 #else
   __sync_fetch_and_and(&_exitflag, 0);
@@ -2552,7 +2552,7 @@ void LibRaw::clearCancelFlag()
 
 void LibRaw::setCancelFlag()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
   InterlockedExchange(&_exitflag, 1);
 #else
   __sync_fetch_and_add(&_exitflag, 1);
@@ -2568,7 +2568,7 @@ void LibRaw::setCancelFlag()
 
 void LibRaw::checkCancel()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
   if (InterlockedExchange(&_exitflag, 0))
     throw LIBRAW_EXCEPTION_CANCELLED_BY_CALLBACK;
 #else
@@ -4131,7 +4131,7 @@ int LibRaw::dcraw_ppm_tiff_writer(const char *filename)
   FILE *f = NULL;
   if(!strcmp(filename,"-"))
     {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
       _setmode(_fileno(stdout),_O_BINARY);
 #endif
       f = stdout;

--- a/src/libraw_datastream.cpp
+++ b/src/libraw_datastream.cpp
@@ -15,7 +15,7 @@
 
 */
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #ifdef __MINGW32__
 #define _WIN32_WINNT 0x0500
 #include <stdexcept>
@@ -63,7 +63,7 @@ LibRaw_file_datastream::~LibRaw_file_datastream()
 
 LibRaw_file_datastream::LibRaw_file_datastream(const char *fname)
     : filename(fname), _fsize(0)
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
       ,
       wfilename()
 #endif
@@ -72,7 +72,7 @@ LibRaw_file_datastream::LibRaw_file_datastream(const char *fname)
 {
   if (filename.size() > 0)
   {
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
     struct stat st;
     if (!stat(filename.c_str(), &st))
       _fsize = st.st_size;
@@ -524,14 +524,14 @@ int LibRaw_buffer_datastream::jpeg_src(void *jpegdata)
 // == LibRaw_bigfile_datastream
 LibRaw_bigfile_datastream::LibRaw_bigfile_datastream(const char *fname)
     : filename(fname)
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
       ,
       wfilename()
 #endif
 {
   if (filename.size() > 0)
   {
-#ifndef WIN32
+#if !defined(WIN32) && !defined(_WIN32)
     struct stat st;
     if (!stat(filename.c_str(), &st))
       _fsize = st.st_size;
@@ -612,7 +612,7 @@ int LibRaw_bigfile_datastream::eof()
 int LibRaw_bigfile_datastream::seek(INT64 o, int whence)
 {
   LR_BF_CHK();
-#if defined(WIN32)
+#if defined(WIN32) || defined(_WIN32)
 #ifdef WIN32SECURECALLS
   return substream ? substream->seek(o, whence) : _fseeki64(f, o, whence);
 #else
@@ -626,7 +626,7 @@ int LibRaw_bigfile_datastream::seek(INT64 o, int whence)
 INT64 LibRaw_bigfile_datastream::tell()
 {
   LR_BF_CHK();
-#if defined(WIN32)
+#if defined(WIN32) || defined(_WIN32)
 #ifdef WIN32SECURECALLS
   return substream ? substream->tell() : _ftelli64(f);
 #else
@@ -730,7 +730,7 @@ int LibRaw_bigfile_datastream::jpeg_src(void *jpegdata)
 }
 
 // == LibRaw_windows_datastream
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 
 LibRaw_windows_datastream::LibRaw_windows_datastream(const TCHAR *sFile)
     : LibRaw_buffer_datastream(NULL, 0), hMap_(0), pView_(NULL)


### PR DESCRIPTION
The WIN32 is not a macro predefined by MSVC, but a custom macro
defined by existing `.vcproj` projects.
The predefined macro while compiling with MSVC is _WIN32.

This patch ensures _WIN32 is properly recognised.
Otherwise, compilation of LibRaw clients (i.e. including headers) using
MSVC requires the extra define of the WIN32 macro.

------

Optimally would be to replace all uses of the custom `WIN32` with `_WIN32` completely, in source code and `.vcproj` files. However, I aimed for a patch that does not change any existing 'behaviours'.
If the replacement is preferred, please let me know, and I will update this PR or submit new one (assuming this one is merged).