### PR TITLE
Fix function prototypes for C-API functions without parameters

### DIFF
--- a/libraw/libraw.h
+++ b/libraw/libraw.h
@@ -62,11 +62,11 @@ extern "C"
   DllDef int libraw_raw2image(libraw_data_t *);
   DllDef void libraw_free_image(libraw_data_t *);
   /* version helpers */
-  DllDef const char *libraw_version();
-  DllDef int libraw_versionNumber();
+  DllDef const char *libraw_version(void);
+  DllDef int libraw_versionNumber(void);
   /* Camera list */
-  DllDef const char **libraw_cameraList();
-  DllDef int libraw_cameraCount();
+  DllDef const char **libraw_cameraList(void);
+  DllDef int libraw_cameraCount(void);
 
   /* helpers */
   DllDef void libraw_set_memerror_handler(libraw_data_t *, memory_callback cb, void *datap);
@@ -76,7 +76,7 @@ extern "C"
   DllDef const char *libraw_unpack_function_name(libraw_data_t *lr);
   DllDef int libraw_get_decoder_info(libraw_data_t *lr, libraw_decoder_info_t *d);
   DllDef int libraw_COLOR(libraw_data_t *, int row, int col);
-  DllDef unsigned libraw_capabilities();
+  DllDef unsigned libraw_capabilities(void);
 
   /* DCRAW compatibility */
   DllDef int libraw_adjust_sizes_info_only(libraw_data_t *);

--- a/src/libraw_c_api.cpp
+++ b/src/libraw_c_api.cpp
@@ -41,12 +41,12 @@ extern "C"
     return &(ret->imgdata);
   }
 
-  unsigned libraw_capabilities() { return LibRaw::capabilities(); }
-  const char *libraw_version() { return LibRaw::version(); }
+  unsigned libraw_capabilities(void) { return LibRaw::capabilities(); }
+  const char *libraw_version(void) { return LibRaw::version(); }
   const char *libraw_strprogress(enum LibRaw_progress p) { return LibRaw::strprogress(p); }
-  int libraw_versionNumber() { return LibRaw::versionNumber(); }
-  const char **libraw_cameraList() { return LibRaw::cameraList(); }
-  int libraw_cameraCount() { return LibRaw::cameraCount(); }
+  int libraw_versionNumber(void) { return LibRaw::versionNumber(); }
+  const char **libraw_cameraList(void) { return LibRaw::cameraList(); }
+  int libraw_cameraCount(void) { return LibRaw::cameraCount(); }
   const char *libraw_unpack_function_name(libraw_data_t *lr)
   {
     if (!lr)


### PR DESCRIPTION
In C, func() and func(void) are different functions: the former accepts an arbitrary number of arguments, while the latter accepts none. In C++ both are the same and accept no arguments.

This PR fixes the C-API code to use func(void) to prevent issues when compiling/linking against the C-API. As the library and the C++-API will always be compiled as C++, they are unchanged.