### PR TITLE
Added extra length check to prevent buffer overflow.

### DIFF
--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -8071,7 +8071,7 @@ void CLASS parseOlympus_CameraSettings (int base, unsigned tag, unsigned type, u
   case 0x0600:
     imgdata.shootinginfo.DriveMode =
     imgdata.makernotes.olympus.DriveMode[0] = get2();
-    for (c = 1; c < len; c++) {
+    for (c = 1; c < 5 && c < len ; c++) {
       imgdata.makernotes.olympus.DriveMode[c] = get2();
     }
     break;


### PR DESCRIPTION
The size of `imgdata.makernotes.olympus.DriveMode` is only 5 but it is possible that `len` has a value larger than `4` and this will result in a buffer overflow. This PR fixes that problem.

This issue can be reproduced with the following file: 
[clusterfuzz-testcase-minimized-ping_dng_fuzzer-5708075144577024.zip](https://github.com/LibRaw/LibRaw/files/3342737/clusterfuzz-testcase-minimized-ping_dng_fuzzer-5708075144577024.zip) that was found with OSS-Fuzz.
