### PR TITLE
Explicitly include some header files

### DIFF
--- a/internal/defines.h
+++ b/internal/defines.h
@@ -53,6 +53,7 @@ it under the terms of the one of two licenses as you choose:
 #define strcasecmp stricmp
 #define strncasecmp strnicmp
 #else
+#include <strings.h>
 #include <unistd.h>
 #include <utime.h>
 #include <netinet/in.h>


### PR DESCRIPTION
When compiling master on Windows 10 with MSYS2. I get the following errors:
- error: ‘swab’ was not declared in this scope
- error: ‘strncasecmp’ was not declared in this scope; did you mean ‘strncmp’?

I've added explicit includes according to the documentation for [swab](http://man7.org/linux/man-pages/man3/swab.3.html) and [strcasecmp](http://man7.org/linux/man-pages/man3/strcasecmp.3.html). I assume this compiles on Unices and on GNU because of some transitive includes.