### PR TITLE
Fixed a buffer underflow: wb_ind can be negative

### DIFF
--- a/internal/dcraw_common.cpp
+++ b/internal/dcraw_common.cpp
@@ -9666,7 +9666,7 @@ void CLASS parsePentaxMakernotes(int base, unsigned tag, unsigned type, unsigned
       getc(ifp);
       for (int wb_cnt = 0; wb_cnt < nPentax_wb_list2; wb_cnt++) {
         wb_ind = getc(ifp);
-        if (wb_ind < nPentax_wb_list2)
+        if (wb_ind >= 0 && wb_ind < nPentax_wb_list2)
           FORC4 imgdata.color.WB_Coeffs[Pentax_wb_list2[wb_ind]][c ^ (c >> 1)] = get2();
       }
   } else if (tag == 0x0239) {  // Q-series lens info (LensInfoQ)


### PR DESCRIPTION
This fixes:

- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13181
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13898
