### PR TITLE
Fix some return types in the documentation

### DIFF
--- a/doc/API-C.html
+++ b/doc/API-C.html
@@ -85,7 +85,7 @@
     <dl>
       <dt>const char* libraw_version()</dt>
       <dd>See <a href="API-CXX.html#version">LibRaw::version()</a></dd>
-      <dt>const char* libraw_versionNumber()</dt>
+      <dt>int libraw_versionNumber()</dt>
       <dt><br>
       </dt>
       <dd>See <a href="API-CXX.html#versionNumber">LibRaw::versionNumber()</a></dd>
@@ -95,13 +95,13 @@
       <dd>See <a href="API-CXX.html#capabilities">LibRaw::capabilities()</a></dd>
       <dt>int libraw_cameraCount()</dt>
       <dd>See <a href="API-CXX.html#cameraCount">LibRaw::cameraCount()</a></dd>
-      <dt>int libraw_cameraList()</dt>
+      <dt>const char** libraw_cameraList()</dt>
       <dd>See <a href="API-CXX.html#cameraList">LibRaw::cameraList()</a></dd>
-      <dt>void libraw_get_decoder_info(libraw_data_t*,libraw_decoder_info_t *);</dt>
+      <dt>int libraw_get_decoder_info(libraw_data_t*, libraw_decoder_info_t *);</dt>
       <dd>See <a href="API-CXX.html#get_decoder_info">LibRaw::get_decoder_info()</a></dd>
-      <dt>void libraw_unpack_function_name(libraw_data_t*);</dt>
+      <dt>const char* libraw_unpack_function_name(libraw_data_t*);</dt>
       <dd>See <a href="API-CXX.html#unpack_function_name">LibRaw::unpack_function_name()</a></dd>
-      <dt>void libraw_COLOR(libraw_data_t*,int row,int col);</dt>
+      <dt>int libraw_COLOR(libraw_data_t*, int row, int col);</dt>
       <dd>See <a href="API-CXX.html#COLOR">LibRaw::COLOR()</a></dd>
       <dt>void libraw_subtract_black(libraw_data_t*);</dt>
       <dd>See <a href="API-CXX.html#add_subtract_black">LibRaw::subtract_black()</a></dd>

--- a/doc/API-CXX.html
+++ b/doc/API-CXX.html
@@ -232,7 +232,7 @@
     <h4>int LibRaw::error_count()</h4>
     <p>This call returns count of non-fatal data errors (out of range, etc) occured in unpack() stage.</p>
     <p><a name="subtract_black"></a></p>
-    <h4>void LibRaw::subtract_black()</h4>
+    <h4>int LibRaw::subtract_black()</h4>
     <p>This call will subtract black level values from RAW data (for suitable RAW data). <a
         href="API-datastruct.html#libraw_colordata_t">colordata.data_maximum</a> and <strong>colordata.maximum</strong> and black level data (<a
         href="API-datastruct.html#libraw_colordata_t">colordata.black</a> and colordata.cblack) will be adjusted too.</p>


### PR DESCRIPTION
I've found some inconsistencies in some return types in the documentation. Mostly the C API. This fixes them.