### PR TITLE
Wide char tweaks

### DIFF
--- a/internal/defines.h
+++ b/internal/defines.h
@@ -26,6 +26,10 @@ it under the terms of the one of two licenses as you choose:
 #endif
 #define DCRAW_VERSION "9.26"
 
+#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#define USE_WCHAR
+#endif
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/internal/defines.h
+++ b/internal/defines.h
@@ -30,6 +30,10 @@ it under the terms of the one of two licenses as you choose:
 #define USE_WCHAR
 #endif
 
+#if _GLIBCXX_HAVE__WFOPEN && _GLIBCXX_USE_WCHAR_T
+#define USE_WCHAR
+#endif
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/libraw/libraw.h
+++ b/libraw/libraw.h
@@ -48,7 +48,7 @@ extern "C"
   DllDef libraw_data_t *libraw_init(unsigned int flags);
   DllDef int libraw_open_file(libraw_data_t *, const char *);
   DllDef int libraw_open_file_ex(libraw_data_t *, const char *, INT64 max_buff_sz);
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   DllDef int libraw_open_wfile(libraw_data_t *, const wchar_t *);
   DllDef int libraw_open_wfile_ex(libraw_data_t *, const wchar_t *, INT64 max_buff_sz);
 #endif
@@ -124,7 +124,7 @@ public:
   LibRaw(unsigned int flags = LIBRAW_OPTIONS_NONE);
   libraw_output_params_t *output_params_ptr() { return &imgdata.params; }
   int open_file(const char *fname, INT64 max_buffered_sz = LIBRAW_USE_STREAMS_DATASTREAM_MAXSIZE);
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   int open_file(const wchar_t *fname, INT64 max_buffered_sz = LIBRAW_USE_STREAMS_DATASTREAM_MAXSIZE);
 #endif
   int open_buffer(void *buffer, size_t size);

--- a/libraw/libraw_const.h
+++ b/libraw/libraw_const.h
@@ -150,7 +150,8 @@ enum LibRaw_dng_processing
 enum LibRaw_runtime_capabilities
 {
   LIBRAW_CAPS_RAWSPEED = 1,
-  LIBRAW_CAPS_DNGSDK = 2
+  LIBRAW_CAPS_DNGSDK = 2,
+  LIBRAW_CAPS_WCHAR = 4,
 };
 
 enum LibRaw_camera_mounts

--- a/libraw/libraw_datastream.h
+++ b/libraw/libraw_datastream.h
@@ -106,7 +106,7 @@ public:
   virtual void unlock() {}
   /* subfile parsing not implemented in base class */
   virtual const char *fname() { return NULL; };
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   virtual const wchar_t *wfname() { return NULL; };
   virtual int subfile_open(const wchar_t *) { return -1; }
 #endif
@@ -148,7 +148,7 @@ protected:
 public:
   virtual ~LibRaw_file_datastream();
   LibRaw_file_datastream(const char *fname);
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   LibRaw_file_datastream(const wchar_t *fname);
 #endif
   virtual void *make_jas_stream();
@@ -168,7 +168,7 @@ public:
   virtual char *gets(char *str, int sz);
   virtual int scanf_one(const char *fmt, void *val);
   virtual const char *fname();
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   virtual const wchar_t *wfname();
   virtual int subfile_open(const wchar_t *fn);
 #endif
@@ -209,7 +209,7 @@ class DllDef LibRaw_bigfile_datastream : public LibRaw_abstract_datastream
 {
 public:
   LibRaw_bigfile_datastream(const char *fname);
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   LibRaw_bigfile_datastream(const wchar_t *fname);
 #endif
   virtual ~LibRaw_bigfile_datastream();
@@ -225,7 +225,7 @@ public:
   virtual char *gets(char *str, int sz);
   virtual int scanf_one(const char *fmt, void *val);
   virtual const char *fname();
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   virtual const wchar_t *wfname();
   virtual int subfile_open(const wchar_t *fn);
 #endif

--- a/src/libraw_c_api.cpp
+++ b/src/libraw_c_api.cpp
@@ -19,6 +19,7 @@ it under the terms of the one of two licenses as you choose:
 
 #include <math.h>
 #include <errno.h>
+#include "internal/defines.h"
 #include "libraw/libraw.h"
 
 #ifdef __cplusplus
@@ -99,7 +100,7 @@ extern "C"
     LibRaw *ip = (LibRaw *)lr->parent_class;
     return ip->open_file(file, sz);
   }
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   int libraw_open_wfile(libraw_data_t *lr, const wchar_t *file)
   {
     if (!lr)

--- a/src/libraw_cxx.cpp
+++ b/src/libraw_cxx.cpp
@@ -180,6 +180,9 @@ unsigned LibRaw::capabilities()
 #ifdef USE_DNGSDK
   ret |= LIBRAW_CAPS_DNGSDK;
 #endif
+#ifdef USE_WCHAR
+  ret |= LIBRAW_CAPS_WCHAR;
+#endif
   return ret;
 }
 

--- a/src/libraw_cxx.cpp
+++ b/src/libraw_cxx.cpp
@@ -30,8 +30,8 @@ it under the terms of the one of two licenses as you choose:
 #include <io.h>
 #endif
 #define LIBRAW_LIBRARY_BUILD
-#include "libraw/libraw.h"
 #include "internal/defines.h"
+#include "libraw/libraw.h"
 #ifdef USE_ZLIB
 #include <zlib.h>
 #endif
@@ -1109,7 +1109,7 @@ int LibRaw::open_file(const char *fname, INT64 max_buf_size)
   return ret;
 }
 
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
 int LibRaw::open_file(const wchar_t *fname, INT64 max_buf_size)
 {
   struct _stati64 st;

--- a/src/libraw_datastream.cpp
+++ b/src/libraw_datastream.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #define LIBRAW_LIBRARY_BUILD
+#include "internal/defines.h"
 #include "libraw/libraw_types.h"
 #include "libraw/libraw.h"
 #include "libraw/libraw_datastream.h"
@@ -97,7 +98,7 @@ LibRaw_file_datastream::LibRaw_file_datastream(const char *fname)
     }
   }
 }
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
 LibRaw_file_datastream::LibRaw_file_datastream(const wchar_t *fname)
     : filename(), wfilename(fname), jas_file(NULL), _fsize(0)
 {
@@ -267,7 +268,7 @@ int LibRaw_file_datastream::subfile_open(const char *fn)
   return 0;
 }
 
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
 int LibRaw_file_datastream::subfile_open(const wchar_t *fn)
 {
   LR_STREAM_CHK();
@@ -322,7 +323,7 @@ void *LibRaw_file_datastream::make_jas_stream()
 #ifdef NO_JASPER
   return NULL;
 #else
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   if (wfname())
   {
     jas_file = _wfopen(wfname(), L"rb");
@@ -346,7 +347,7 @@ int LibRaw_file_datastream::jpeg_src(void *jpegdata)
     fclose(jas_file);
     jas_file = NULL;
   }
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
   if (wfname())
   {
     jas_file = _wfopen(wfname(), L"rb");
@@ -556,7 +557,7 @@ LibRaw_bigfile_datastream::LibRaw_bigfile_datastream(const char *fname)
   sav = 0;
 }
 
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
 LibRaw_bigfile_datastream::LibRaw_bigfile_datastream(const wchar_t *fname) : filename(), wfilename(fname)
 {
   if (wfilename.size() > 0)
@@ -676,7 +677,7 @@ int LibRaw_bigfile_datastream::subfile_open(const char *fn)
   else
     return 0;
 }
-#if defined(_WIN32) && !defined(__MINGW32__) && defined(_MSC_VER) && (_MSC_VER > 1310)
+#ifdef USE_WCHAR
 int LibRaw_bigfile_datastream::subfile_open(const wchar_t *fn)
 {
   if (sav)


### PR DESCRIPTION
This does a couple of things. The most notable being `wchar_t` support in MINGW (as long as the libstdc++ version supports it). This will also work for non-Windows platforms compiled with GNU libstdc++ that provides a `wchar_t` type.

The other new thing is the `wchar_t` support being exposed in the `LibRaw_runtime_capabilities` enum.