### PR TITLE
ColorSpace tag support for preview color management in Canon raw files

### DIFF
--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -317,6 +317,7 @@ typedef unsigned long long UINT64;
     short MakernotesFlip;
     short SRAWQuality;
     unsigned wbi;
+    short ColorSpace;
   } libraw_canon_makernotes_t;
 
   typedef struct

--- a/src/metadata/canon.cpp
+++ b/src/metadata/canon.cpp
@@ -703,6 +703,10 @@ void LibRaw::parseCanonMakernotes(unsigned tag, unsigned type, unsigned len, uns
     Canon_WBpresets(0, 0);
     fseek(ifp, save1, SEEK_SET);
   }
+  else if (tag == 0x00b4)
+  {
+    imCanon.ColorSpace = get2(); // 1 = sRGB, 2 = Adobe RGB
+  }
   else if (tag == 0x00e0)
   { // SensorInfo
     imCanon.SensorWidth = (get2(), get2());


### PR DESCRIPTION
There is a need to extract the ColorSpace setting in the raw Canon camera files. To display a preview of these files in the correct color space. When using AdodeRGB this always creates problems with the correct display of these previews, so this tag is needed.
Added a new ColorSpace member to the libraw_canon_makernotes_t structure, and filling it in LibRaw :: parseCanonMakernotes (code 0x00b4, proof https://exiftool.org/TagNames/Canon.html)