### PR TITLE
ColorSpace tag support for preview color management in Nikon raw files

### DIFF
--- a/libraw/libraw_const.h
+++ b/libraw/libraw_const.h
@@ -541,4 +541,11 @@ enum LibRaw_image_formats
   LIBRAW_IMAGE_BITMAP = 2
 };
 
+enum LibRaw_colorspaces
+{
+  LIBRAW_COLORSPACE_Unknown = 0,
+  LIBRAW_COLORSPACE_sRGB = 1,
+  LIBRAW_COLORSPACE_AdobeRGB = 2
+};
+
 #endif

--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -692,6 +692,7 @@ typedef unsigned long long UINT64;
                       7    Never seen
                       8    Name unknown
                       */
+    short MakernoteColorSpace;
   } libraw_colordata_t;
 
   typedef struct

--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -487,6 +487,7 @@ typedef unsigned long long UINT64;
     libraw_sensor_highspeed_crop_t SensorHighSpeedCrop;
     ushort SensorWidth;
     ushort SensorHeight;
+    short ColorSpace;
   } libraw_nikon_makernotes_t;
 
   typedef struct

--- a/src/metadata/canon.cpp
+++ b/src/metadata/canon.cpp
@@ -705,7 +705,19 @@ void LibRaw::parseCanonMakernotes(unsigned tag, unsigned type, unsigned len, uns
   }
   else if (tag == 0x00b4)
   {
-    imCanon.ColorSpace = get2(); // 1 = sRGB, 2 = Adobe RGB
+    imCanon.ColorSpace = get2();
+    switch (imCanon.ColorSpace)
+    {
+    case 1:
+      imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_sRGB;
+      break;
+    case 2:
+      imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_AdobeRGB;
+      break;
+    default:
+      imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_Unknown;
+      break;
+    }
   }
   else if (tag == 0x00e0)
   { // SensorInfo

--- a/src/metadata/ciff.cpp
+++ b/src/metadata/ciff.cpp
@@ -307,6 +307,22 @@ void LibRaw::parse_ciff(int offset, int length, int depth)
     {
       timestamp = get4();
     }
+    else if (type == 0x00b4)
+    {
+      imCanon.ColorSpace = get2();
+      switch (imCanon.ColorSpace)
+      {
+      case 1:
+        imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_sRGB;
+        break;
+      case 2:
+        imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_AdobeRGB;
+        break;
+      default:
+        imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_Unknown;
+        break;
+      }
+    }
 
 #ifdef LOCALTIME
     if ((type | 0x4000) == 0x580e)

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -2832,5 +2832,7 @@ notraw:
   else
     imgdata.color.raw_bps = tiff_bps;
 
+  imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_Unknown;
+
   RUN_CALLBACK(LIBRAW_PROGRESS_IDENTIFY, 1, 2);
 }

--- a/src/metadata/nikon.cpp
+++ b/src/metadata/nikon.cpp
@@ -450,6 +450,10 @@ void LibRaw::parseNikonMakernote(int base, int uptag, unsigned dng_writer)
           sprintf(imgdata.shootinginfo.BodySerial, "%d", serial);
       }
     }
+    else if (tag == 0x001e)
+    { // ColorSpace
+      imNikon.ColorSpace = get2(); // 1 = sRGB, 2 = Adobe RGB
+    }
     else if (tag == 0x0025)
     {
       if (!iso_speed || (iso_speed == 65535))

--- a/src/metadata/nikon.cpp
+++ b/src/metadata/nikon.cpp
@@ -452,7 +452,19 @@ void LibRaw::parseNikonMakernote(int base, int uptag, unsigned dng_writer)
     }
     else if (tag == 0x001e)
     { // ColorSpace
-      imNikon.ColorSpace = get2(); // 1 = sRGB, 2 = Adobe RGB
+      imNikon.ColorSpace = get2();
+      switch (imNikon.ColorSpace)
+      {
+      case 1:
+        imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_sRGB;
+        break;
+      case 2:
+        imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_AdobeRGB;
+        break;
+      default:
+        imgdata.color.MakernoteColorSpace = LIBRAW_COLORSPACE_Unknown;
+        break;
+      }
     }
     else if (tag == 0x0025)
     {


### PR DESCRIPTION
There is a need to extract the ColorSpace setting in the raw Nikon camera files. To display a preview of these files in the correct color space. When using AdodeRGB this always creates problems with the correct display of these previews, so this tag is needed.
Added a new ColorSpace member to the libraw_nikon_makernotes_t structure, and filling it in LibRaw :: parseNikonMakernote (code 0x001e, proof https://exiftool.org/TagNames/Nikon.html)