### PR TITLE
Added color.ExifColorSpace and makernotes.common.ColorSpace

### DIFF
--- a/internal/dcraw_defs.h
+++ b/internal/dcraw_defs.h
@@ -49,6 +49,7 @@
 #define imPentax imgdata.makernotes.pentax
 #define imSamsung imgdata.makernotes.samsung
 #define imSony imgdata.makernotes.sony
+#define imCommon imgdata.makernotes.common
 
 #define ph1_bits(n) ph1_bithuff(n, 0)
 #define ph1_huff(h) ph1_bithuff(*h, h + 1)

--- a/internal/libraw_internal_funcs.h
+++ b/internal/libraw_internal_funcs.h
@@ -283,6 +283,7 @@ it under the terms of the one of two licenses as you choose:
     void        parse_thumb_note (int base, unsigned toff, unsigned tlen);
     void        parse_makernote (int base, int uptag);
     void        parse_makernote_0xc634(int base, int uptag, unsigned dng_writer);
+    void        parse_interop(int base);
     void        parse_exif (int base);
     void        linear_table (unsigned len);
     void        Kodak_DCR_WBtags(int wb, unsigned type, int wbi);

--- a/libraw/libraw_const.h
+++ b/libraw/libraw_const.h
@@ -541,4 +541,13 @@ enum LibRaw_image_formats
   LIBRAW_IMAGE_BITMAP = 2
 };
 
+enum LibRaw_colorspaces
+{
+  LIBRAW_COLORSPACE_Unknown = 0,
+  LIBRAW_COLORSPACE_sRGB = 1,
+  LIBRAW_COLORSPACE_AdobeRGB = 2,
+  LIBRAW_COLORSPACE_WideGamutRGB = 3,
+  LIBRAW_COLORSPACE_ProPhotoRGB = 4
+};
+
 #endif

--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -317,7 +317,6 @@ typedef unsigned long long UINT64;
     short MakernotesFlip;
     short SRAWQuality;
     unsigned wbi;
-    short ColorSpace;
   } libraw_canon_makernotes_t;
 
   typedef struct
@@ -691,6 +690,7 @@ typedef unsigned long long UINT64;
                       7    Never seen
                       8    Name unknown
                       */
+    ushort ExifColorSpace; // from ExifIFD.ColorSpace + InteropIndex, see enum LibRaw_colorspaces
   } libraw_colordata_t;
 
   typedef struct
@@ -743,6 +743,7 @@ typedef unsigned long long UINT64;
     float exifCameraElevationAngle;
     float real_ISO;
     float exifExposureIndex;
+    ushort ColorSpace; // see enum LibRaw_colorspaces
   } libraw_metadata_common_t;
 
   typedef struct

--- a/src/metadata/canon.cpp
+++ b/src/metadata/canon.cpp
@@ -705,7 +705,7 @@ void LibRaw::parseCanonMakernotes(unsigned tag, unsigned type, unsigned len, uns
   }
   else if (tag == 0x00b4)
   {
-    imCanon.ColorSpace = get2(); // 1 = sRGB, 2 = Adobe RGB
+    imCommon.ColorSpace = get2();
   }
   else if (tag == 0x00e0)
   { // SensorInfo

--- a/src/metadata/ciff.cpp
+++ b/src/metadata/ciff.cpp
@@ -307,6 +307,10 @@ void LibRaw::parse_ciff(int offset, int length, int depth)
     {
       timestamp = get4();
     }
+    else if (type == 0x00b4)
+    {
+      imCommon.ColorSpace = get2();
+    }
 
 #ifdef LOCALTIME
     if ((type | 0x4000) == 0x580e)

--- a/src/metadata/exif_gps.cpp
+++ b/src/metadata/exif_gps.cpp
@@ -38,7 +38,7 @@ void LibRaw::parse_interop(int base)
     switch (tag)
     {
     case 0x0001: // InteropIndex
-      value = get4();
+      fread(&value, 1, 4, ifp);
       if (value == 0x383952 && // "R98"
                                // Canon bug, when [Canon].ColorSpace = AdobeRGB,
                                // but [ExifIFD].ColorSpace = Uncalibrated and

--- a/src/metadata/exif_gps.cpp
+++ b/src/metadata/exif_gps.cpp
@@ -23,6 +23,8 @@ void LibRaw::parse_interop(int base)
   unsigned entries, tag, type, len, save;
   unsigned value;
   entries = get2();
+  const unsigned int kR98 = order == 0x4949 ? 0x383952 : 0x52393800;
+  const unsigned int kR03 = order == 0x4949 ? 0x333052 : 0x33305200;
   INT64 fsize = ifp->size();
   while (entries--)
   {
@@ -39,13 +41,12 @@ void LibRaw::parse_interop(int base)
     {
     case 0x0001: // InteropIndex
       value = get4();
-      if (value == 0x383952 && // "R98"
-                               // Canon bug, when [Canon].ColorSpace = AdobeRGB,
-                               // but [ExifIFD].ColorSpace = Uncalibrated and
-                               // [InteropIFD].InteropIndex = "R98"
+      if (value == kR98 && // Canon bug, when [Canon].ColorSpace = AdobeRGB,
+                           // but [ExifIFD].ColorSpace = Uncalibrated and
+                           // [InteropIFD].InteropIndex = "R98"
           imgdata.color.ExifColorSpace == LIBRAW_COLORSPACE_Unknown)
         imgdata.color.ExifColorSpace = LIBRAW_COLORSPACE_sRGB;
-      else if (value == 0x333052) // "R03"
+      else if (value == kR03)
         imgdata.color.ExifColorSpace = LIBRAW_COLORSPACE_AdobeRGB;
       break;
     }

--- a/src/metadata/exif_gps.cpp
+++ b/src/metadata/exif_gps.cpp
@@ -21,7 +21,7 @@
 void LibRaw::parse_interop(int base)
 {
   unsigned entries, tag, type, len, save;
-  unsigned value;
+  char value[4];
   entries = get2();
   INT64 fsize = ifp->size();
   while (entries--)
@@ -38,14 +38,15 @@ void LibRaw::parse_interop(int base)
     switch (tag)
     {
     case 0x0001: // InteropIndex
-      value = get4();
-      if (value == 0x383952 && // "R98"
+      memset(value, 0, sizeof(value));
+      fread(value, 1, MIN(4,len), ifp);
+      if (strncmp(value, "R98", 3) == 0 &&
                                // Canon bug, when [Canon].ColorSpace = AdobeRGB,
                                // but [ExifIFD].ColorSpace = Uncalibrated and
                                // [InteropIFD].InteropIndex = "R98"
           imgdata.color.ExifColorSpace == LIBRAW_COLORSPACE_Unknown)
         imgdata.color.ExifColorSpace = LIBRAW_COLORSPACE_sRGB;
-      else if (value == 0x333052) // "R03"
+      else if (strncmp(value, "R03", 3) == 0)
         imgdata.color.ExifColorSpace = LIBRAW_COLORSPACE_AdobeRGB;
       break;
     }

--- a/src/metadata/exif_gps.cpp
+++ b/src/metadata/exif_gps.cpp
@@ -23,8 +23,6 @@ void LibRaw::parse_interop(int base)
   unsigned entries, tag, type, len, save;
   unsigned value;
   entries = get2();
-  const unsigned int kR98 = order == 0x4949 ? 0x383952 : 0x52393800;
-  const unsigned int kR03 = order == 0x4949 ? 0x333052 : 0x33305200;
   INT64 fsize = ifp->size();
   while (entries--)
   {
@@ -41,12 +39,13 @@ void LibRaw::parse_interop(int base)
     {
     case 0x0001: // InteropIndex
       value = get4();
-      if (value == kR98 && // Canon bug, when [Canon].ColorSpace = AdobeRGB,
-                           // but [ExifIFD].ColorSpace = Uncalibrated and
-                           // [InteropIFD].InteropIndex = "R98"
+      if (value == 0x383952 && // "R98"
+                               // Canon bug, when [Canon].ColorSpace = AdobeRGB,
+                               // but [ExifIFD].ColorSpace = Uncalibrated and
+                               // [InteropIFD].InteropIndex = "R98"
           imgdata.color.ExifColorSpace == LIBRAW_COLORSPACE_Unknown)
         imgdata.color.ExifColorSpace = LIBRAW_COLORSPACE_sRGB;
-      else if (value == kR03)
+      else if (value == 0x333052) // "R03"
         imgdata.color.ExifColorSpace = LIBRAW_COLORSPACE_AdobeRGB;
       break;
     }

--- a/src/metadata/exif_gps.cpp
+++ b/src/metadata/exif_gps.cpp
@@ -38,7 +38,7 @@ void LibRaw::parse_interop(int base)
     switch (tag)
     {
     case 0x0001: // InteropIndex
-      fread(&value, 1, 4, ifp);
+      value = get4();
       if (value == 0x383952 && // "R98"
                                // Canon bug, when [Canon].ColorSpace = AdobeRGB,
                                // but [ExifIFD].ColorSpace = Uncalibrated and

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -474,6 +474,9 @@ void LibRaw::identify()
           imgdata.makernotes.common.AmbientTemperature = imgdata.makernotes.common.BatteryTemperature =
               imgdata.makernotes.common.exifAmbientTemperature = -1000.0f;
 
+  imgdata.color.ExifColorSpace = LIBRAW_COLORSPACE_Unknown;
+  imgdata.makernotes.common.ColorSpace = LIBRAW_COLORSPACE_Unknown;
+
   for (i = 0; i < LIBRAW_IFD_MAXCOUNT; i++)
   {
     tiff_ifd[i].dng_color[0].illuminant = tiff_ifd[i].dng_color[1].illuminant =

--- a/src/metadata/nikon.cpp
+++ b/src/metadata/nikon.cpp
@@ -450,6 +450,10 @@ void LibRaw::parseNikonMakernote(int base, int uptag, unsigned dng_writer)
           sprintf(imgdata.shootinginfo.BodySerial, "%d", serial);
       }
     }
+    else if (tag == 0x001e)
+    { // ColorSpace
+      imCommon.ColorSpace = get2();
+    }
     else if (tag == 0x0025)
     {
       if (!iso_speed || (iso_speed == 65535))

--- a/src/metadata/olympus.cpp
+++ b/src/metadata/olympus.cpp
@@ -217,6 +217,20 @@ void LibRaw::parseOlympus_CameraSettings(int base, unsigned tag, unsigned type,
     break;
   case 0x0507:
     imOly.ColorSpace = get2();
+    switch (imOly.ColorSpace)
+    {
+    case 0:
+      imCommon.ColorSpace = LIBRAW_COLORSPACE_sRGB;
+      break;
+    case 1:
+      imCommon.ColorSpace = LIBRAW_COLORSPACE_AdobeRGB;
+      break;
+    case 2:
+      imCommon.ColorSpace = LIBRAW_COLORSPACE_ProPhotoRGB;
+      break;
+    default:
+      imCommon.ColorSpace = LIBRAW_COLORSPACE_Unknown;
+    }
     break;
   case 0x0600:
     imgdata.shootinginfo.DriveMode = imOly.DriveMode[0] = get2();

--- a/src/metadata/pentax.cpp
+++ b/src/metadata/pentax.cpp
@@ -293,6 +293,10 @@ void LibRaw::parsePentaxMakernotes(int base, unsigned tag, unsigned type,
     }
     imgdata.shootinginfo.DriveMode = imPentax.DriveMode[0];
   }
+  else if (tag == 0x0037)
+  { // ColorSpace
+    imCommon.ColorSpace = get2()+1;
+  }
   else if (tag == 0x0038)
   {
     imgdata.sizes.raw_inset_crop.cleft = get2();


### PR DESCRIPTION
I suggest adding two new elements: ExifColorSpace in libraw_colordata_t, and ColorSpace in libraw_metadata_common_t. ExifColorSpace will contain the values from ExifIFD.ColorSpace. ColorSpace will contain values from vendors makernotes. This is necessary in order to determine the ColorSpace camera settings and correctly display camera previews in the corresponding ColorSpace. Currently verified by Canon, Nikon, Sony, Fuji, Olympus, Pentax,
