### PR TITLE
Update URL to dcraw.c file

### DIFF
--- a/mkdist.sh
+++ b/mkdist.sh
@@ -7,7 +7,7 @@ else
     autoreconf --install
     mkdir dcraw
     cd dcraw
-    wget http://www.cybercom.net/~dcoffin/dcraw/dcraw.c
+    wget https://www.dechifro.org/dcraw/dcraw.c
     cd ..
     rm -f clist2c.pl clist2html.pl
     rm -f Makefile.devel 


### PR DESCRIPTION
Hey there,

the URL to the `dcraw.c` file seems doesn't seem to be valid anymore.

I updated it to what I found to be the new location.