### PR TITLE
Add -I<include_dir> to support users that use #include <libraw/libraw.h>

### DIFF
--- a/libraw.pc.in
+++ b/libraw.pc.in
@@ -8,4 +8,4 @@ Description: Raw image decoder library (non-thread-safe)
 Requires: @PACKAGE_REQUIRES@
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
-Cflags: -I${includedir}/libraw
+Cflags: -I${includedir}/libraw -I${includedir}

--- a/libraw_r.pc.in
+++ b/libraw_r.pc.in
@@ -8,4 +8,4 @@ Description: Raw image decoder library (thread-safe)
 Requires: @PACKAGE_REQUIRES@
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
-Cflags: -I${includedir}/libraw
+Cflags: -I${includedir}/libraw -I${includedir}


### PR DESCRIPTION
For example, GEGL (gegl.org) uses that style of include.