### PR TITLE
Upstreaming Google's LibRaw fork stability, security and performance changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-object/*.o
-lib/libraw_r.a
-lib/libraw.a
-bin/*
-!bin/.keepme

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+object/*.o
+lib/libraw_r.a
+lib/libraw.a
+bin/*
+!bin/.keepme

--- a/internal/libraw_internal_funcs.h
+++ b/internal/libraw_internal_funcs.h
@@ -156,6 +156,7 @@ it under the terms of the one of two licenses as you choose:
     void        ljpeg_end(struct jhead *jh);
     int         ljpeg_diff (ushort *huff);
     ushort *    ljpeg_row (int jrow, struct jhead *jh);
+    ushort *    ljpeg_row_unrolled (int jrow, struct jhead *jh);
     void	    ljpeg_idct (struct jhead *jh);
     unsigned    ph1_bithuff (int nbits, ushort *huff);
 

--- a/libraw/libraw.h
+++ b/libraw/libraw.h
@@ -326,7 +326,7 @@ protected:
   virtual void copy_bayer(unsigned short cblack[4], unsigned short *dmaxp);
   virtual void fuji_rotate();
   virtual void convert_to_rgb_loop(float out_cam[3][4]);
-  virtual void lin_interpolate_loop(int code[16][16][32], int size);
+  virtual void lin_interpolate_loop(int *code, int size);
   virtual void scale_colors_loop(float scale_mul[4]);
 
   /* Fujifilm compressed decoder public interface (to make parallel decoder) */

--- a/src/decoders/load_mfbacks.cpp
+++ b/src/decoders/load_mfbacks.cpp
@@ -30,7 +30,7 @@ void LibRaw::phase_one_flat_field(int is_float, int nc)
   float *mrow, num, mult[4];
 
   read_shorts(head, 8);
-  if (head[2] * head[3] * head[4] * head[5] == 0)
+  if (head[2] == 0 || head[3] == 0 || head[4] == 0 || head[5] == 0)
     return;
   wide = head[2] / head[4] + (head[2] % head[4] != 0);
   high = head[3] / head[5] + (head[3] % head[5] != 0);
@@ -568,7 +568,7 @@ void LibRaw::hasselblad_load_raw()
           FORC(2)
           {
             diff[s + c] = ph1_bits(len[c]);
-            if ((diff[s + c] & (1 << (len[c] - 1))) == 0)
+            if (len[c] > 0 && (diff[s + c] & (1 << (len[c] - 1))) == 0)
               diff[s + c] -= (1 << len[c]) - 1;
             if (diff[s + c] == 65535)
               diff[s + c] = -32768;

--- a/src/demosaic/misc_demosaic.cpp
+++ b/src/demosaic/misc_demosaic.cpp
@@ -103,7 +103,7 @@ void LibRaw::border_interpolate(int border)
     }
 }
 
-void LibRaw::lin_interpolate_loop(int code[16][16][32], int size)
+void LibRaw::lin_interpolate_loop(int *code, int size)
 {
   int row;
   for (row = 1; row < height - 1; row++)
@@ -115,7 +115,7 @@ void LibRaw::lin_interpolate_loop(int code[16][16][32], int size)
       int i;
       int sum[4];
       pix = image[row * width + col];
-      ip = code[row % size][col % size];
+      ip = code + ((((row % size) * 16) + (col % size)) * 32);
       memset(sum, 0, sizeof sum);
       for (i = *ip++; i--; ip += 3)
         sum[ip[2]] += pix[ip[0]] << ip[1];
@@ -127,7 +127,8 @@ void LibRaw::lin_interpolate_loop(int code[16][16][32], int size)
 
 void LibRaw::lin_interpolate()
 {
-  int code[16][16][32], size = 16, *ip, sum[4];
+  std::vector<int> code_buffer(16 * 16 * 32);
+  int* code = &code_buffer[0], size = 16, *ip, sum[4];
   int f, c, x, y, row, col, shift, color;
 
   RUN_CALLBACK(LIBRAW_PROGRESS_INTERPOLATE, 0, 3);
@@ -138,7 +139,7 @@ void LibRaw::lin_interpolate()
   for (row = 0; row < size; row++)
     for (col = 0; col < size; col++)
     {
-      ip = code[row][col] + 1;
+      ip = code + (((row * 16) + col) * 32) + 1;
       f = fcol(row, col);
       memset(sum, 0, sizeof sum);
       for (y = -1; y <= 1; y++)
@@ -153,7 +154,7 @@ void LibRaw::lin_interpolate()
           *ip++ = color;
           sum[color] += 1 << shift;
         }
-      code[row][col][0] = (ip - code[row][col]) / 3;
+      code[(row * 16 + col) * 32] = (ip - (code + ((row * 16) + col) * 32)) / 3;
       FORCC
       if (c != f)
       {

--- a/src/demosaic/xtrans_demosaic.cpp
+++ b/src/demosaic/xtrans_demosaic.cpp
@@ -224,9 +224,8 @@ void LibRaw::xtrans_interpolate(int passes)
                 g = 2 * rix[0][1] - rix[i << c][1] - rix[-i << c][1];
                 color[h][d] = g + rix[i << c][h] + rix[-i << c][h];
                 if (d > 1)
-                  diff[d] += SQR(rix[i << c][1] - rix[-i << c][1] -
-                                 rix[i << c][h] + rix[-i << c][h]) +
-                             SQR(g);
+                  diff[d] += SQR((float)rix[i << c][1] - (float)rix[-i << c][1] -
+                  (float)rix[i << c][h] + (float)rix[-i << c][h]) + SQR((float)g);
               }
               if (d > 1 && (d & 1))
                 if (diff[d - 1] < diff[d])

--- a/src/metadata/fuji.cpp
+++ b/src/metadata/fuji.cpp
@@ -938,10 +938,11 @@ void LibRaw::parse_fuji(int offset)
     else if (tag == 0x0131) // XTransLayout
     {
       filters = 9;
+      char *xtrans_abs_alias = &xtrans_abs[0][0];
       FORC(36)
       {
         int q = fgetc(ifp);
-        xtrans_abs[0][35 - c] = MAX(0, MIN(q, 2)); /* & 3;*/
+        xtrans_abs_alias[35 - c] = MAX(0, MIN(q, 2)); /* & 3;*/
       }
     }
     else if (tag == 0x2ff0) // WB_GRGBLevels

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -392,7 +392,7 @@ void LibRaw::identify()
 
   // clang-format on
 
-  char head[64], *cp;
+  char head[64] = {0}, *cp;
   int hlen, fsize, zero_fsize = 1, i, c;
   struct jhead jh;
 
@@ -2157,8 +2157,8 @@ void LibRaw::identify_finetune_dcr(char head[64], int fsize)
 			height = raw_height;
 		}
 
-		top_margin = (raw_height - height) >> 2 << 1;
-		left_margin = (raw_width - width) >> 2 << 1;
+		top_margin = (raw_height >= height) ? (raw_height - height) >> 2 << 1 : 0;
+		left_margin = (raw_width >= width) ? (raw_width - width) >> 2 << 1 : 0;
 
 		if (!strcmp(model, "X-T3") || !strcmp(model, "X-T4") || !strcmp(model, "X100V") || !strcmp(model, "X-T30") || !strcmp(model, "X-Pro3"))
 		{

--- a/src/metadata/mediumformat.cpp
+++ b/src/metadata/mediumformat.cpp
@@ -318,7 +318,8 @@ void LibRaw::parse_phase_one(int base)
 void LibRaw::parse_mos(int offset)
 {
   char data[40];
-  int skip, from, i, c, neut[4], planes = 0, frot = 0;
+  int from, i, c, neut[4], planes = 0, frot = 0;
+  unsigned skip;
   static const char *mod[] = {
       /* DM22, DM28, DM40, DM56 are somewhere here too */
       "",             //  0
@@ -364,7 +365,7 @@ void LibRaw::parse_mos(int offset)
   float romm_cam[3][3];
 
   fseek(ifp, offset, SEEK_SET);
-  while (1)
+  while (!feof(ifp))
   {
     if (get4() != 0x504b5453)
       break;

--- a/src/metadata/sony.cpp
+++ b/src/metadata/sony.cpp
@@ -105,7 +105,7 @@ void LibRaw::sony_decrypt(unsigned *data, int len, int start, int key)
   if (start)
   {
     for (p = 0; p < 4; p++)
-      pad[p] = key = key * 48828125 + 1;
+      pad[p] = key = key * 48828125ULL + 1;
     pad[3] = pad[3] << 1 | (pad[0] ^ pad[2]) >> 31;
     for (p = 4; p < 127; p++)
       pad[p] = (pad[p - 4] ^ pad[p - 2]) << 1 | (pad[p - 3] ^ pad[p - 1]) >> 31;

--- a/src/postprocessing/dcraw_process.cpp
+++ b/src/postprocessing/dcraw_process.cpp
@@ -91,9 +91,11 @@ int LibRaw::dcraw_process(void)
       if (load_raw == &LibRaw::x3f_load_raw)
       {
         // Filter out zeroes
-        for (int i = 0; i < S.height * S.width * 4; i++)
-          if ((short)imgdata.image[0][i] < 0)
-            imgdata.image[0][i] = 0;
+        for (int i = 0; i < S.height * S.width; i++) {
+          for (int c = 0; c < 4; c++)
+            if ((short)imgdata.image[i][c] < 0)
+              imgdata.image[i][c] = 0;
+        }
       }
       SET_PROC_FLAG(LIBRAW_PROGRESS_FOVEON_INTERPOLATE);
     }

--- a/src/postprocessing/dcraw_process.cpp
+++ b/src/postprocessing/dcraw_process.cpp
@@ -91,7 +91,8 @@ int LibRaw::dcraw_process(void)
       if (load_raw == &LibRaw::x3f_load_raw)
       {
         // Filter out zeroes
-        for (int i = 0; i < S.height * S.width; i++) {
+        for (int i = 0; i < S.height * S.width; i++)
+        {
           for (int c = 0; c < 4; c++)
             if ((short)imgdata.image[i][c] < 0)
               imgdata.image[i][c] = 0;

--- a/src/postprocessing/mem_image.cpp
+++ b/src/postprocessing/mem_image.cpp
@@ -119,15 +119,30 @@ void LibRaw::get_mem_image_format(int *width, int *height, int *colors,
                                   int *bps) const
 
 {
+  *width = S.width;
+  *height = S.height;
+  if (imgdata.progress_flags < LIBRAW_PROGRESS_FUJI_ROTATE)
+  {
+    if (O.use_fuji_rotate)
+    {
+      if (IO.fuji_width)
+      {
+        int fuji_width = (IO.fuji_width - 1 + IO.shrink) >> IO.shrink;
+        *width = (ushort)(fuji_width / sqrt(0.5));
+        *height = (ushort)((*height - fuji_width) / sqrt(0.5));
+      }
+      else
+      {
+        if (S.pixel_aspect < 0.995)
+          *height = (ushort)(*height / S.pixel_aspect + 0.5);
+        if (S.pixel_aspect > 1.005)
+          *width = (ushort)(*width * S.pixel_aspect + 0.5);
+      }
+    }
+  }
   if (S.flip & 4)
   {
-    *width = S.height;
-    *height = S.width;
-  }
-  else
-  {
-    *width = S.width;
-    *height = S.height;
+    std::swap(*width, *height);
   }
   *colors = P1.colors;
   *bps = O.output_bps;

--- a/src/preprocessing/subtract_black.cpp
+++ b/src/preprocessing/subtract_black.cpp
@@ -39,26 +39,26 @@ int LibRaw::subtract_black_internal()
       int dmax = 0;
       if (C.cblack[4] && C.cblack[5])
       {
-        for (i = 0; i < size * 4; i++)
-        {
-          int val = imgdata.image[0][i];
-          val -= C.cblack[6 + i / 4 / S.iwidth % C.cblack[4] * C.cblack[5] +
-                          i / 4 % S.iwidth % C.cblack[5]];
-          val -= cblk[i & 3];
-          imgdata.image[0][i] = CLIP(val);
-          if (dmax < val)
-            dmax = val;
+        for (unsigned i = 0; i < size; i++) {
+          for (unsigned c = 0; c < 4; c++) {
+            int val = imgdata.image[i][c];
+            val -= C.cblack[6 + i / S.iwidth % C.cblack[4] * C.cblack[5] +
+                            i % S.iwidth % C.cblack[5]];
+            val -= cblk[c];
+            imgdata.image[i][c] = CLIP(val);
+            if (dmax < val) dmax = val;
+          }
         }
       }
       else
       {
-        for (i = 0; i < size * 4; i++)
-        {
-          int val = imgdata.image[0][i];
-          val -= cblk[i & 3];
-          imgdata.image[0][i] = CLIP(val);
-          if (dmax < val)
-            dmax = val;
+        for (unsigned i = 0; i < size; i++) {
+          for (unsigned c = 0; c < 4; c++) {
+            int val = imgdata.image[i][c];
+            val -= cblk[c];
+            imgdata.image[i][c] = CLIP(val);
+            if (dmax < val) dmax = val;
+          }
         }
       }
       C.data_maximum = dmax & 0xffff;

--- a/src/preprocessing/subtract_black.cpp
+++ b/src/preprocessing/subtract_black.cpp
@@ -39,8 +39,10 @@ int LibRaw::subtract_black_internal()
       int dmax = 0;
       if (C.cblack[4] && C.cblack[5])
       {
-        for (unsigned i = 0; i < size; i++) {
-          for (unsigned c = 0; c < 4; c++) {
+        for (unsigned i = 0; i < size; i++)
+        {
+          for (unsigned c = 0; c < 4; c++)
+          {
             int val = imgdata.image[i][c];
             val -= C.cblack[6 + i / S.iwidth % C.cblack[4] * C.cblack[5] +
                             i % S.iwidth % C.cblack[5]];
@@ -52,8 +54,10 @@ int LibRaw::subtract_black_internal()
       }
       else
       {
-        for (unsigned i = 0; i < size; i++) {
-          for (unsigned c = 0; c < 4; c++) {
+        for (unsigned i = 0; i < size; i++)
+        {
+          for (unsigned c = 0; c < 4; c++)
+          {
             int val = imgdata.image[i][c];
             val -= cblk[c];
             imgdata.image[i][c] = CLIP(val);

--- a/src/tables/colordata.cpp
+++ b/src/tables/colordata.cpp
@@ -1723,9 +1723,9 @@ int LibRaw::adobe_coeff(unsigned make_idx, const char *t_model,
 			  {
 				  for (raw_color = j = 0; j < 12; j++)
 					  if (internal_only)
-						  imgdata.color.cam_xyz[0][j] = table[i].trans[j] / 10000.0;
+						  imgdata.color.cam_xyz[j / 3][j % 3] = table[i].trans[j] / 10000.0;
 					  else
-						  imgdata.color.cam_xyz[0][j] = ((double *)cam_xyz)[j] =
+						  imgdata.color.cam_xyz[j / 3][j % 3] =
 						  table[i].trans[j] / 10000.0;
 				  if (!internal_only)
 					  cam_xyz_coeff(rgb_cam, cam_xyz);

--- a/src/tables/colordata.cpp
+++ b/src/tables/colordata.cpp
@@ -1725,7 +1725,7 @@ int LibRaw::adobe_coeff(unsigned make_idx, const char *t_model,
 					  if (internal_only)
 						  imgdata.color.cam_xyz[j / 3][j % 3] = table[i].trans[j] / 10000.0;
 					  else
-						  imgdata.color.cam_xyz[j / 3][j % 3] =
+						  imgdata.color.cam_xyz[j / 3][j % 3] = ((double *)cam_xyz)[j] =
 						  table[i].trans[j] / 10000.0;
 				  if (!internal_only)
 					  cam_xyz_coeff(rgb_cam, cam_xyz);


### PR DESCRIPTION
This PR upstreams changes made to Google's internal fork of LibRaw.

These changes are around:
- address sanitization
- fixing misc crashes and minor bugs
- unrolling loops for performance gains (see comparison below)
![unnamed](https://user-images.githubusercontent.com/13925440/82067240-70d18580-969e-11ea-9979-df2c3799811d.png)

Please let me know if there are any additions that you would prefer not added or any requested changes, thank you!

/cc @nchusid @wwkc
