### PR TITLE
Update INSTALL instructions to highlight mkdist.sh

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,9 +7,10 @@ I. Installation steps
 
  $  tar xzvf LibRaw-0.xx.yy.tar.gz
 
-2. Go to LibRaw folder and run ./configure and make:
+2. Go to LibRaw folder and run mkdist.sh, ./configure and make:
 
  $ cd LibRaw-0.xx.yy
+ $ ./mkdist.sh
  $ ./configure  [...optional args...]
  $ make
 


### PR DESCRIPTION
Highlight that, after downloading the LibRaw release tarball (eg https://github.com/LibRaw/LibRaw/releases/tag/0.19.5), you need to run `mkdist.sh` to generate the `configure` script.