### PR TITLE
Fix ljpeg_diff bug

### DIFF
--- a/src/decoders/decoders_dcraw.cpp
+++ b/src/decoders/decoders_dcraw.cpp
@@ -370,9 +370,7 @@ int LibRaw::ljpeg_diff(ushort *huff)
     return -32768;
   diff = getbits(len);
 
-  len = MAX(1, len);
-
-  if ((diff & (1 << (len - 1))) == 0)
+  if ((diff & (len > 0 ? (1 << (len - 1)) : 0)) == 0)
     diff -= (1 << len) - 1;
   return diff;
 }


### PR DESCRIPTION
Turns out this bit of code was relying on the invariant 1 << (0 - 1) = 0 which was broken in https://github.com/LibRaw/LibRaw/commit/8fe8757931eb3e23e8fd23dd613501193febdd57

This can be verified trying to unpack [canon_eos_400d.zip](https://github.com/LibRaw/LibRaw/files/4788272/canon_eos_400d.zip)

@LibRaw would you be open to me adding some automated testing with GitHub Actions? (free for open source projects!) The tests would simply verify "happy paths" continue to work with changes which would catch bugs like these.



