### PR TITLE
Fix invalid shift when len=0

### DIFF
--- a/src/decoders/decoders_dcraw.cpp
+++ b/src/decoders/decoders_dcraw.cpp
@@ -371,7 +371,7 @@ int LibRaw::ljpeg_diff(ushort *huff)
   diff = getbits(len);
 
 
-  if ((diff & (1 << (len - 1))) == 0)
+  if (len > 0 && (diff & (1 << (len - 1))) == 0)
     diff -= (1 << len) - 1;
   return diff;
 }


### PR DESCRIPTION
third_party/libraw/src/decoders/decoders_dcraw.cpp:377:28: runtime error: shift exponent -1 is negative
    #0 0x7fb74c75682b in LibRaw::ljpeg_diff(unsigned short*) third_party/libraw/src/decoders/decoders_dcraw.cpp:377:28
    #1 0x7fb74c758996 in LibRaw::ljpeg_row_unrolled(int, jhead*) third_party/libraw/src/decoders/decoders_dcraw.cpp:487:16
    #2 0x7fb74c7576c7 in LibRaw::ljpeg_row(int, jhead*) third_party/libraw/src/decoders/decoders_dcraw.cpp:390:12
    #3 0x7fb74c759b7a in LibRaw::lossless_jpeg_load_raw() third_party/libraw/src/decoders/decoders_dcraw.cpp:569:12
    #4 0x7fb74c7a8535 in LibRaw::unpack() third_party/libraw/src/decoders/unpack.cpp:287:7