### PR TITLE
Use a const void *buffer in 'open_buffer'

### DIFF
--- a/libraw/libraw.h
+++ b/libraw/libraw.h
@@ -86,7 +86,7 @@ extern "C"
   DllDef int libraw_open_wfile_ex(libraw_data_t *, const wchar_t *,
                                   INT64 max_buff_sz);
 #endif
-  DllDef int libraw_open_buffer(libraw_data_t *, void *buffer, size_t size);
+  DllDef int libraw_open_buffer(libraw_data_t *, const void *buffer, size_t size);
   DllDef int libraw_unpack(libraw_data_t *);
   DllDef int libraw_unpack_thumb(libraw_data_t *);
   DllDef void libraw_recycle_datastream(libraw_data_t *);
@@ -171,7 +171,7 @@ public:
   int open_file(const wchar_t *fname,
                 INT64 max_buffered_sz = LIBRAW_USE_STREAMS_DATASTREAM_MAXSIZE);
 #endif
-  int open_buffer(void *buffer, size_t size);
+  int open_buffer(const void *buffer, size_t size);
   virtual int open_datastream(LibRaw_abstract_datastream *);
   virtual int open_bayer(unsigned char *data, unsigned datalen,
                          ushort _raw_width, ushort _raw_height,

--- a/libraw/libraw_datastream.h
+++ b/libraw/libraw_datastream.h
@@ -156,7 +156,7 @@ public:
 class DllDef LibRaw_buffer_datastream : public LibRaw_abstract_datastream
 {
 public:
-  LibRaw_buffer_datastream(void *buffer, size_t bsize);
+  LibRaw_buffer_datastream(const void *buffer, size_t bsize);
   virtual ~LibRaw_buffer_datastream();
   virtual int valid();
   virtual void *make_jas_stream();

--- a/src/libraw_c_api.cpp
+++ b/src/libraw_c_api.cpp
@@ -120,7 +120,7 @@ extern "C"
     return ip->open_file(file, sz);
   }
 #endif
-  int libraw_open_buffer(libraw_data_t *lr, void *buffer, size_t size)
+  int libraw_open_buffer(libraw_data_t *lr, const void *buffer, size_t size)
   {
     if (!lr)
       return EINVAL;

--- a/src/libraw_datastream.cpp
+++ b/src/libraw_datastream.cpp
@@ -348,7 +348,7 @@ void *LibRaw_file_datastream::make_jas_stream()
 }
 
 // == LibRaw_buffer_datastream
-LibRaw_buffer_datastream::LibRaw_buffer_datastream(void *buffer, size_t bsize)
+LibRaw_buffer_datastream::LibRaw_buffer_datastream(const void *buffer, size_t bsize)
 {
   buf = (unsigned char *)buffer;
   streampos = 0;

--- a/src/utils/open.cpp
+++ b/src/utils/open.cpp
@@ -128,10 +128,10 @@ int LibRaw::open_file(const wchar_t *fname, INT64 max_buf_size)
 #endif
 #endif
 
-int LibRaw::open_buffer(void *buffer, size_t size)
+int LibRaw::open_buffer(const void *buffer, size_t size)
 {
   // this stream will close on recycle()
-  if (!buffer || buffer == (void *)-1)
+  if (!buffer || buffer == (const void *)-1)
     return LIBRAW_IO_ERROR;
 
   LibRaw_buffer_datastream *stream;


### PR DESCRIPTION
While writing [Rust bindings to LibRaw's C APIs](https://github.com/paolobarbolini/libraw-rs), I noticed `libraw_open_buffer` takes `void *buffer` instead of `const void *buffer`. This makes me have to make my function take a mutable reference to a slice, which shouldn't be necessary as this is supposed to just read without ever modifying the input buffer.

## Very simplified example of what I have to do on my side

```rust
// what I can do with the changes from this PR
pub fn what_i_expect(self, buf: &[u8]) -> Result<ProcessedImage> {
    unsafe {
        libraw_open_buffer(self.inner, buf.as_ptr() as *const _, buf.len())
    };
    // rest of the code
}

// what I can do with the code from the current master
pub fn what_i_got(self, buf: &mut [u8]) -> Result<ProcessedImage> {
    unsafe {
        libraw_open_buffer(self.inner, buf.as_mut_ptr() as *mut _, buf.len())
    };
    // rest of the code
}
```

If I really wanted to I could transform an immutable reference into a mutable one, but that would be highly unsafe, so I prefered fixing this upstream if possible. 

I have very little experience with C and C++, so if this can't be done feel free to close this PR, but I feel like a `const void *buffer` should be fine for `open_buffer`.