### PR TITLE
raw-identify: use fallback if PATH_MAX not available

### DIFF
--- a/samples/raw-identify.cpp
+++ b/samples/raw-identify.cpp
@@ -40,7 +40,11 @@ it under the terms of the one of two licenses as you choose:
 #include <sys/mman.h>
 #include <sys/time.h>
 #ifndef MAX_PATH
+#ifdef PATH_MAX
 #define MAX_PATH PATH_MAX
+#else
+#define MAX_PATH 4096
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
`PATH_MAX` is optional in POSIX, so define a fallback value if not available. While ideally it should not be relied upon, a fallback value is enough for a sample application.