### PR TITLE
LibRaw::raw2image: prevent OOB buffer access of color4_image

### DIFF
--- a/src/preprocessing/raw2image.cpp
+++ b/src/preprocessing/raw2image.cpp
@@ -156,7 +156,7 @@ int LibRaw::raw2image(void)
                     &imgdata.rawdata
                          .color4_image[(row + S.top_margin) * S.raw_pitch / 8 +
                                        S.left_margin],
-                    S.width * sizeof(*imgdata.image));
+                width * sizeof(*imgdata.image));
         }
       }
       else if (imgdata.rawdata.color3_image)

--- a/src/preprocessing/raw2image.cpp
+++ b/src/preprocessing/raw2image.cpp
@@ -143,7 +143,15 @@ int LibRaw::raw2image(void)
                   S.width * S.height * sizeof(*imgdata.image));
         else
         {
-          for (int row = 0; row < S.height; row++)
+            // To prevent OOB buffer access of color4_image
+            if (S.raw_width < S.left_margin)
+            {
+                throw LIBRAW_EXCEPTION_DECODE_RAW;
+            }
+            int width = MIN(S.width, S.raw_width - S.left_margin);
+            for (int row = 0; row < S.height && (row + S.top_margin) < S.raw_height;
+                row++)
+            {
             memmove(&imgdata.image[row * S.width],
                     &imgdata.rawdata
                          .color4_image[(row + S.top_margin) * S.raw_pitch / 8 +


### PR DESCRIPTION
Prevent OOB buffer access of color4_image;
Please check if this is fixed in newer version;
This pull request tries not to change original codes too much; Also throwing error may not be necessary, please incorporate this fix to the best place. 