### PR TITLE
fix memory corruption if raw_stride < _raw_stride

### DIFF
--- a/src/decoders/decoders_libraw_dcrdefs.cpp
+++ b/src/decoders/decoders_libraw_dcrdefs.cpp
@@ -76,6 +76,10 @@ void LibRaw::broadcom_load_raw()
   uchar *data, *dp;
   int rev, row, col, c;
   ushort _raw_stride = (ushort)load_flags;
+#ifdef USE_6BY9RPI
+  if (raw_stride)
+    _raw_stride = raw_stride;
+#endif
   rev = 3 * (order == 0x4949);
   data = (uchar *)malloc(_raw_stride * 2);
   merror(data, "broadcom_load_raw()");

--- a/src/decoders/decoders_libraw_dcrdefs.cpp
+++ b/src/decoders/decoders_libraw_dcrdefs.cpp
@@ -77,7 +77,7 @@ void LibRaw::broadcom_load_raw()
   int rev, row, col, c;
   ushort _raw_stride = (ushort)load_flags;
   rev = 3 * (order == 0x4949);
-  data = (uchar *)malloc(raw_stride * 2);
+  data = (uchar *)malloc(_raw_stride * 2);
   merror(data, "broadcom_load_raw()");
 
   for (row = 0; row < raw_height; row++)


### PR DESCRIPTION
When calling `LibRaw::unpack` with Broadcom image data if `raw_stride` equals to `0` , LibRaw corrupts the heap `data` .
