### PR TITLE
Add Libs.private to libraw.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ if test x$jpeg = xtrue; then
                         AC_CHECK_HEADERS([jpeglib.h], [
                                 CPPFLAGS="$CPPFLAGS -DUSE_JPEG -DUSE_JPEG8"
                                 LIBS="$LIBS -ljpeg"
+                                AC_SUBST([PACKAGE_LIBS_PRIVATE],"-ljpeg $PACKAGE_LIBS_PRIVATE")
                         ], AC_MSG_WARN([no jpeg headers found]))
                 ],
                 AC_MSG_WARN([libjpeg not found])
@@ -78,6 +79,7 @@ if test x$jasper = xtrue; then
                         AC_CHECK_HEADERS([jasper/jasper.h], [
                                 CPPFLAGS="$CPPFLAGS -DUSE_JASPER"
                                 LIBS="$LIBS -ljasper"
+                                AC_SUBST([PACKAGE_LIBS_PRIVATE],"-ljasper $PACKAGE_LIBS_PRIVATE")
                         ], AC_MSG_WARN([no jasper headers found]))
                 ],
                 AC_MSG_WARN([libjasper not found])

--- a/libraw.pc.in
+++ b/libraw.pc.in
@@ -8,4 +8,5 @@ Description: Raw image decoder library (non-thread-safe)
 Requires: @PACKAGE_REQUIRES@
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
+Libs.private: @PACKAGE_LIBS_PRIVATE@
 Cflags: -I${includedir}/libraw -I${includedir}

--- a/libraw_r.pc.in
+++ b/libraw_r.pc.in
@@ -8,4 +8,5 @@ Description: Raw image decoder library (thread-safe)
 Requires: @PACKAGE_REQUIRES@
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
+Libs.private: @PACKAGE_LIBS_PRIVATE@
 Cflags: -I${includedir}/libraw -I${includedir}


### PR DESCRIPTION
Add `Libs.private` to `libraw.pc` to avoid the following static build failure when enabling libraw with jasper support in imagemagick:

```
/home/giuliobenetti/autobuild/run/instance-1/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: /home/giuliobenetti/autobuild/run/instance-1/output-1/host/bin/../arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libjasper.a(jpg_enc.c.o): in function `jpg_encode':
jpg_enc.c:(.text+0x1f4): undefined reference to `jpeg_stdio_dest'
```

`-ljpeg` must be added after `-ljasper` because jasper depends on jpeg

Fixes:
 - http://autobuild.buildroot.org/results/88e43a1ea2059a684e50b0f5f2af407e8c6df2e1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>