### PR TITLE
Minor fixes for ClangCl on MSVC

### DIFF
--- a/src/decoders/fp_dng.cpp
+++ b/src/decoders/fp_dng.cpp
@@ -551,7 +551,7 @@ void LibRaw::convertFloatToInt(float dmin /* =4096.f */,
 }
 
 static
-#if defined(_MSC_VER)
+#if (defined(_MSC_VER) && !defined(__clang__))
 _forceinline
 #else
 inline
@@ -567,7 +567,7 @@ void swap24(uchar *data, int len)
 }
 
 static
-#if defined(_MSC_VER)
+#if (defined(_MSC_VER) && !defined(__clang__))
 _forceinline
 #else
 inline

--- a/src/libraw_datastream.cpp
+++ b/src/libraw_datastream.cpp
@@ -787,7 +787,7 @@ LibRaw_bigfile_buffered_datastream::LibRaw_bigfile_buffered_datastream(const wch
             OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0)) != INVALID_HANDLE_VALUE)
 #endif
         {
-            if (fhandle > 0)
+            if (fhandle != NULL)
             {
                 LARGE_INTEGER fs;
                 if (GetFileSizeEx(fhandle, &fs))
@@ -811,11 +811,11 @@ const wchar_t *LibRaw_bigfile_buffered_datastream::wfname()
 
 LibRaw_bigfile_buffered_datastream::~LibRaw_bigfile_buffered_datastream()
 {
-    if (fhandle > 0)
+    if (fhandle != NULL)
         CloseHandle(fhandle);
 }
 int LibRaw_bigfile_buffered_datastream::valid() {
-    return fhandle > 0 && fhandle != INVALID_HANDLE_VALUE;
+    return (fhandle != NULL) && (fhandle != INVALID_HANDLE_VALUE);
 }
 
 const char *LibRaw_bigfile_buffered_datastream::fname()


### PR DESCRIPTION
This PR adds two minor changes to make the code compile with ClangCl (from LLVM 12) on MSVC. ClangCl is a very nice compiler frontend for the Microsoft-Compiler MSVC.