### PR TITLE
Fix uninitialized variables in LibRaw::parse_tiff_ifd

### DIFF
--- a/src/metadata/tiff.cpp
+++ b/src/metadata/tiff.cpp
@@ -24,7 +24,7 @@ int LibRaw::parse_tiff_ifd(int base)
   unsigned entries, tag, type, len, plen = 16, save, utmp;
   int ifd, use_cm = 0, cfa, i, j, c, ima_len = 0;
   char *cbuf, *cp;
-  uchar cfa_pat[16], cfa_pc[] = {0, 1, 2, 3}, tab[256];
+  uchar cfa_pat[16] = {0}, cfa_pc[] = {0, 1, 2, 3}, tab[256] = {0};
   double fm[3][4], cc[4][4], cm[4][3], cam_xyz[4][3], num;
   double ab[] = {1, 1, 1, 1}, asn[] = {0, 0, 0, 0}, xyz[] = {1, 1, 1};
   unsigned sony_curve[] = {0, 0, 0, 0, 0, 4095};


### PR DESCRIPTION
Fix https://github.com/LibRaw/LibRaw/issues/426: Initialize array elements of ``cfa_pat`` and ``tab`` with zero in [src/metadata/tiff.cpp#L27](https://github.com/LibRaw/LibRaw/blob/68b409baf660c57f88e509eac9b1c2b1aea33983/src/metadata/tiff.cpp#L27). Thus we can stop ``filters`` using of uninitialized value in [src/metadata/tiff.cpp#L943](https://github.com/LibRaw/LibRaw/blob/68b409baf660c57f88e509eac9b1c2b1aea33983/src/metadata/tiff.cpp#L943)