### PR TITLE
Fix UBSan complain

### DIFF
--- a/src/metadata/tiff.cpp
+++ b/src/metadata/tiff.cpp
@@ -650,7 +650,7 @@ int LibRaw::parse_tiff_ifd(int base)
       {
         tiff_ifd[ifd].t_filters = filters = 9;
         colors = 3;
-        FORC(36) xtrans[0][c] = fgetc(ifp) & 3;
+        FORC(36)((char *)xtrans)[c] = fgetc(ifp) & 3;
       }
       else if (len > 0)
       {


### PR DESCRIPTION
While technically there is no issue, UBSan in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31839 complains about out of bands access. The fix is to make it exactly the same as at line 645.