### PR TITLE
add canon CRM support

### DIFF
--- a/internal/libraw_internal_funcs.h
+++ b/internal/libraw_internal_funcs.h
@@ -56,7 +56,10 @@ it under the terms of the one of two licenses as you choose:
 	ushort	sget2Rev(uchar *s);
 	libraw_area_t	get_CanonArea();
 	int	parseCR3(INT64 oAtomList, INT64 szAtomList, short &nesting, char *AtomNameStack, short& nTrack, short &TrackType);
-	void	selectCRXTrack(short maxTrack);
+	void 	selectCRXTrack();
+	void    parseCR3_Free();
+	int     parseCR3_CTMD(short trackNum);
+	int     selectCRXFrame(short trackNum, unsigned frameIndex);
 	void	setCanonBodyFeatures (unsigned long long id);
 	void	processCanonCameraInfo (unsigned long long id, uchar *CameraInfo, unsigned maxlen, unsigned type, unsigned dng_writer);
 	static float _CanonConvertAperture(ushort in);
@@ -373,7 +376,7 @@ it under the terms of the one of two licenses as you choose:
 	void fuji_14bit_load_raw();
 	void parse_fuji_compressed_header();
 	void crxLoadRaw();
-	int  crxParseImageHeader(uchar *cmp1TagData, int nTrack);
+	int  crxParseImageHeader(uchar *cmp1TagData, int nTrack, int size);
 	void panasonicC6_load_raw();
 	void panasonicC7_load_raw();
 

--- a/libraw/libraw_internal.h
+++ b/libraw/libraw_internal.h
@@ -113,6 +113,13 @@ typedef struct
   int metadata_blocks;
 } identify_data_t;
 
+typedef struct
+{
+  uint32_t first;
+  uint32_t count;
+  uint32_t id;
+} crx_sample_to_chunk_t;
+
 // contents of tag CMP1 for relevant track in CR3 file
 typedef struct
 {
@@ -129,10 +136,18 @@ typedef struct
   int32_t hasTileCols;
   int32_t hasTileRows;
   int32_t mdatHdrSize;
+  int32_t medianBits;
   // Not from header, but from datastream
   uint32_t MediaSize;
   INT64 MediaOffset;
-  uint32_t MediaType; /* 1 -> /C/RAW, 2-> JPEG */
+  uint32_t MediaType; /* 1 -> /C/RAW, 2-> JPEG, 3-> CTMD metadata*/
+  crx_sample_to_chunk_t * stsc_data; /* samples to chunk */
+  uint32_t stsc_count;
+  uint32_t sample_count;
+  uint32_t sample_size; /* zero if not fixed sample size */
+  int32_t *sample_sizes;
+  uint32_t chunk_count;
+  INT64  *chunk_offsets;
 } crx_data_header_t;
 
 typedef struct
@@ -163,6 +178,7 @@ typedef struct
   int pana_encoding, pana_bpp;
   crx_data_header_t crx_header[LIBRAW_CRXTRACKS_MAXCOUNT];
   int crx_track_selected;
+  int crx_track_count;
   short CR3_CTMDtag;
   short CR3_Version;
   int CM_found;

--- a/src/metadata/canon.cpp
+++ b/src/metadata/canon.cpp
@@ -1216,6 +1216,7 @@ void LibRaw::parseCanonMakernotes(unsigned tag, unsigned type, unsigned len, uns
       CR3_ColorData(0x0047);
       break;
 
+    case 1770: // R5 CRM
     case 2024: // -1D X Mark III; ColorDataSubVer: 32
     case 3656: // R5, R6; ColorDataSubVer: 33
       imCanon.ColorDataVer = 10;

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -434,6 +434,7 @@ void LibRaw::identify()
   CM_found = 0;
   memset(tiff_ifd, 0, sizeof tiff_ifd);
   libraw_internal_data.unpacker_data.crx_track_selected = -1;
+  libraw_internal_data.unpacker_data.crx_track_count -1;
   libraw_internal_data.unpacker_data.CR3_CTMDtag = 0;
   imHassy.nIFD_CM[0] = imHassy.nIFD_CM[1] = -1;
   imKodak.ISOCalibrationGain = 1.0f;
@@ -706,9 +707,10 @@ void LibRaw::identify()
 
     szAtomList = ifp->size();
     err = parseCR3(0ULL, szAtomList, nesting, AtomNameStack, nTrack, TrackType);
+    libraw_internal_data.unpacker_data.crx_track_count = nTrack;
     if ((err == 0 || err == -14) &&
         nTrack >= 0) // no error, or too deep nesting
-      selectCRXTrack(nTrack);
+      selectCRXTrack();
   }
 
   if (dng_version)

--- a/src/utils/init_close_utils.cpp
+++ b/src/utils/init_close_utils.cpp
@@ -150,6 +150,8 @@ void LibRaw::recycle()
   FREE(imgdata.rawdata.raw_alloc);
   FREE(imgdata.idata.xmpdata);
 
+  parseCR3_Free();
+
 #undef FREE
 
   ZERO(imgdata.sizes);


### PR DESCRIPTION
This version now uses only shot_select and should be just internal API changes.

Here is a collection of R5 CRM samples:
https://www.dropbox.com/sh/ty32q952xdzv3no/AAAIw1t7-ZRqH3TrpQoBfavMa?dl=0

Data wise there appears to be 6 main variations. 

 - StandardRaw - sRGB
 - StandardRaw - CLOG
 - StandardRaw - CLOG3
 - LightRaw - sRGB
 - LightRaw - CLOG
 - LightRaw - CLOG3

CLOG and CLOG3 have more headroom in the highlights and is darker then sRGB when decoded
CLOG is suppose the have approx. 800% and CLOG3 1600% according [manual](https://cam.start.canon/en/C003/manual/html/UG-03_Shooting-2_0080.html)

colormatix and colorspace are presumed to be metadata tags.

LightRaw also bakes in the white balance, but it can be reversed by inversing the "As Shot" white balance.
