### PR TITLE
add minimal makernote data for CRM developing

### DIFF
--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -305,6 +305,16 @@ typedef unsigned long long UINT64;
     int AutoLightingOptimizer;
     int HighlightTonePriority;
 
+    /* -1 = n/a            1 = Economy
+        2 = Normal         3 = Fine
+        4 = RAW            5 = Superfine
+        7 = CRAW         130 = Normal Movie, CRM LightRaw
+      131 = CRM  StandardRaw */
+    short Quality;
+    /* Increases dynamic range of sensor data
+        0 = OFF  1 = CLogV1 2 = CLogV2? 3 = CLogV3 */
+    int CanonLog;
+
    libraw_area_t DefaultCropAbsolute;
    libraw_area_t RecommendedImageArea;   // contains the image in proper aspect ratio?
    libraw_area_t LeftOpticalBlack;       // use this, when present, to estimate black levels?

--- a/src/metadata/canon.cpp
+++ b/src/metadata/canon.cpp
@@ -587,7 +587,9 @@ void LibRaw::processCanonCameraInfo(unsigned long long id, uchar *CameraInfo,
 
 void LibRaw::Canon_CameraSettings(unsigned len)
 {
-  fseek(ifp, 10, SEEK_CUR);
+  fseek(ifp, 6, SEEK_CUR);
+  imCanon.Quality = get2();   // 3
+  get2();
   imgdata.shootinginfo.DriveMode = get2(); // 5
   get2();
   imgdata.shootinginfo.FocusMode = get2(); // 7
@@ -1285,6 +1287,9 @@ void LibRaw::parseCanonMakernotes(unsigned tag, unsigned type, unsigned len, uns
       imCanon.multishot[3] = get4();
     }
     FORC4 cam_mul[c] = 1024;
+  } else if (tag == 0x4026) {
+    fseek(ifp, 44, SEEK_CUR);
+    imCanon.CanonLog = get4();
   }
 #undef CR3_ColorData
 #undef sRAW_WB


### PR DESCRIPTION
This should be the minimal metadata need to develop a CRM raw. 
- Quality - previously identified by [exiftool](https://exiftool.org/TagNames/Canon.html#CameraSettings) can be used to determine if the file is StandardRaw or LightRaw.
- CanonLog - what version of CanonLog is being used.

I did identify the colorspace and colormatrix metadata in another [version](https://github.com/markreidvfx/LibRaw/commit/b26a613d94bfc51bfb60b13c7b098c951ba985f6). The data is just before the CanonLog data,  but they don't effect the encoded data. Since this would be external change, I didn't want to add too much.

(On a side note, I also noticed some of the libraw_canon_makernotes_t values like FlashMode is are not set anywhere. A few of them appear to be in Camera Settings tag)
