### PR TITLE
use medianBits for bps for encType 3

### DIFF
--- a/src/decoders/crx.cpp
+++ b/src/decoders/crx.cpp
@@ -1702,7 +1702,7 @@ void crxConvertPlaneLine(CrxImage *img, int imageRow, int imageCol = 0, int plan
     int16_t *plane3 = plane2 + planeSize;
 
     int32_t median = (1 << (img->medianBits - 1)) << 10;
-    int32_t maxVal = (1 << img->nBits) - 1;
+    int32_t maxVal = (1 << img->medianBits) - 1;
     uint32_t rawLineOffset = 4 * img->planeWidth * imageRow;
 
     // for this stage - all except imageRow is ignored

--- a/src/metadata/cr3_parser.cpp
+++ b/src/metadata/cr3_parser.cpp
@@ -177,7 +177,7 @@ void LibRaw::selectCRXTrack()
     raw_width = d->f_width;
     raw_height = d->f_height;
     load_raw = &LibRaw::crxLoadRaw;
-    tiff_bps = d->nBits;
+    tiff_bps = d->encType == 3? d->medianBits : d->nBits;
     switch (d->cfaLayout)
     {
     case 0:


### PR DESCRIPTION
This solves the clamping issues I'm having. I think it makes sense with the black/whites levels in the file.

- 1024 -> 14888 StandardRaw - sRGB    
- 1024 -> 14008 StandardRaw - CLOG   
- 1024 -> 14888 StandardRaw - CLOG3 
- 1024 -> 14888 LightRaw  - sRGB          
- 1024 -> 14008 LightRaw  - CLOG         
- 1024 -> 14888 LightRaw  - CLOG3

I wanted to rename medianBits to something else, but couldn't think of good name to call it.
       