### PR TITLE
Olympus OM-1 Support

### DIFF
--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -42,6 +42,7 @@ static const struct
     {LIBRAW_CAMERAMAKER_Nikon,          "Nikon"},
     {LIBRAW_CAMERAMAKER_Nokia,          "Nokia"},
     {LIBRAW_CAMERAMAKER_Olympus,        "Olympus"},
+	{LIBRAW_CAMERAMAKER_Olympus,        "OM Digital Solutions"},
     {LIBRAW_CAMERAMAKER_Ricoh,          "Ricoh"},
     {LIBRAW_CAMERAMAKER_Pentax,         "Pentax"},
     {LIBRAW_CAMERAMAKER_PhaseOne,       "Phase One"},

--- a/src/metadata/makernotes.cpp
+++ b/src/metadata/makernotes.cpp
@@ -442,6 +442,13 @@ void LibRaw::parse_makernote(int base, int uptag)
     if (buf[0] == 'O')
       get2();
   }
+  else if(!strcmp(buf, "OM SYSTEM"))
+  {
+      base = ftell(ifp) - 10;
+	  fseek(ifp, 2, SEEK_CUR);
+	  order = get2();
+      get2();
+  }
   else if (!strncmp(buf, "SONY", 4) || // DSLR-A100
            !strcmp(buf, "Panasonic")) {
     if (buf[0] == 'S')
@@ -484,7 +491,7 @@ void LibRaw::parse_makernote(int base, int uptag)
   }
 
   if (!is_Olympus &&
-      (!strncasecmp(make, "Olympus", 7) ||
+      (!strncasecmp(make, "Olympus", 7) || !strncasecmp(make, "OM Digital Solutions", 20) ||
       (!strncasecmp(make, "CLAUSS", 6) && !strncasecmp(model, "piX 5oo", 7)))) {
     is_Olympus = 1;
   }

--- a/src/metadata/tiff.cpp
+++ b/src/metadata/tiff.cpp
@@ -1881,7 +1881,7 @@ void LibRaw::apply_tiff()
         filters = 0;
         break;
       }
-      if ((!strncmp(make, "OLYMPUS", 7) ||
+      if ((!strncmp(make, "OLYMPUS", 7) || !strncmp(make, "OM Digital Solutions", 20) ||
            (!strncasecmp(make, "CLAUSS", 6) &&
             !strncasecmp(model, "piX 5oo", 7))) && // 0x5330303539 works here
           (INT64(tiff_ifd[raw].bytes) * 2ULL ==
@@ -1913,7 +1913,7 @@ void LibRaw::apply_tiff()
         load_flags = 0;
       case 16:
         load_raw = &LibRaw::unpacked_load_raw;
-        if ((!strncmp(make, "OLYMPUS", 7) ||
+        if ((!strncmp(make, "OLYMPUS", 7) || !strncmp(make, "OM Digital Solutions", 20) ||
              (!strncasecmp(make, "CLAUSS", 6) &&
               !strncasecmp(model, "piX 5oo", 7))) && // 0x5330303539 works here
             (INT64(tiff_ifd[raw].bytes) * 7ULL >


### PR DESCRIPTION
Enables library to correctly identify makernote and access thumbnail.