### PR TITLE
bug fix: remove extra omp barrier

### DIFF
--- a/src/demosaic/ahd_demosaic.cpp
+++ b/src/demosaic/ahd_demosaic.cpp
@@ -348,10 +348,6 @@ void LibRaw::ahd_interpolate()
         }
     }
 
-#ifdef LIBRAW_USE_OPENMP
-#pragma omp barrier
-#endif
-
     free_omp_buffers(buffers, buffer_count);
 
     if (terminate_flag)


### PR DESCRIPTION
There is an "omp barrier" outside of the parallel loop, so this is useless (ignored by omp by default) but could have some side effects.
In my use case, I read multiple RAW images within an omp loop. This extra/useless barrier locks my main loop and create a dead lock. I have tested this fix and it solves my issue.
