### PR TITLE
Fix various typos

### DIFF
--- a/README.demosaic-packs
+++ b/README.demosaic-packs
@@ -1,7 +1,7 @@
 ======================= LibRaw demosaic pack(s) ===============================
 
 We were forced to stop supporting LibRaw demosaic packs: the contributed code
-is out of date for several years, inital contributors has no interest in it.
+is out of date for several years, initial contributors has no interest in it.
 
 We too: we (LibRaw team) focused on RAW decode and metadata extraction, but not
 on postprocessing (demosaic, noise suppression, etc).

--- a/doc/API-datastruct.html
+++ b/doc/API-datastruct.html
@@ -114,7 +114,7 @@
       <dt><strong> libraw_thumbnail_t thumbnail; </strong></dt>
       <dd>Data structure containing information on the preview and the preview
         data themselves. All fields of this structure but thumbnail itself are
-        filled when open_file() is called. Thumbnail readed by unpack_thumb()
+        filled when open_file() is called. Thumbnail read by unpack_thumb()
         call. The fields are described in detail <a href="#libraw_thumbnail_t">
           below </a> .</dd>
       <dt><strong> libraw_rawdata_t rawdata; </strong></dt>
@@ -280,7 +280,7 @@
       <dt><strong> float rgb_cam[3][4]; </strong></dt>
       <dd>Camera to sRGB conversion matrix</dd>
       <dt><strong> float ccm[3][4]; </strong></dt>
-      <dd>Camera color correction matrix readed from file metadata (uniform
+      <dd>Camera color correction matrix read from file metadata (uniform
         matrix if no such data in file)</dd>
       <dt><strong> ph1_t phase_one_data; </strong></dt>
       <dd>Color data block that is read for Phase One cameras.</dd>
@@ -298,10 +298,10 @@
       <dt><strong> unsigned profile_length; </strong></dt>
       <dd>Length of ICC profile in bytes.</dd>
       <dt><strong> unsigned black_stat[8]; </strong></dt>
-      <dd>Black level statistics if calcluated from masked area: 4 sum of pixel
+      <dd>Black level statistics if calculated from masked area: 4 sum of pixel
         values, than 4 pixel counts (per channel).</dd>
       <dt><strong> libraw_dng_color_t dng_color[2]; </strong></dt>
-      <dd>Color data read from DNG: illuminant, calbiration matrix and color
+      <dd>Color data read from DNG: illuminant, calibration matrix and color
         matrix for two light sources. (see DNG specs for details).</dd>
       <dt><strong>libraw_dng_levels_t dng_levels</strong></dt>
       <dd>DNG black/white levels, analog balance, WB for active IFD. See DNG
@@ -351,7 +351,7 @@
     <h3>Structure libraw_rawdata_t: holds unpacked RAW data</h3>
     <p>Structure libraw_rawdata_t holds:</p>
     <ul>
-      <li>RAW-data from sensor, readed and unpacked by the <a href="API-CXX.html#unpack">
+      <li>RAW-data from sensor, read and unpacked by the <a href="API-CXX.html#unpack">
           unpack() </a> call.</li>
       <li>"backup" copy of color and over data modified during postprocessing.
         When postprocessing calls repeats, the needed data is restored from this
@@ -680,7 +680,7 @@
         Don't use automatic increase of brightness by histogram.</dd>
       <dt><strong> float auto_bright_thr; </strong></dt>
       <dd><strong> dcraw keys: </strong> none <br>
-        Portion of clipped pixels when auto brighness increase is used. Default
+        Portion of clipped pixels when auto brightness increase is used. Default
         value is 0.01 (1%) for dcraw compatibility. Recommended value for modern
         low-noise multimegapixel cameras depends on shooting style. Values in
         0.001-0.00003 range looks reasonable.</dd>
@@ -900,7 +900,7 @@
     <p>Definition:</p>
     <pre>	class LibRaw_abstract_datastream {...protected: LibRaw_abstract_datastream *substream;}
 </pre>
-    <p><strong> Description: </strong> Ojects derived from
+    <p><strong> Description: </strong> Objects derived from
       LibRaw_abstract_datastream always contains pointer to secondary data
       stream (substream). This substream initialized internally when needed
       (really used only for Sony RAW data) and used for temporary switch input

--- a/internal/libraw_cameraids.h
+++ b/internal/libraw_cameraids.h
@@ -90,9 +90,9 @@ it under the terms of the one of two licenses as you choose:
 #define CanonID_EOS_R6            (0x80000000ULL + 0x453ULL)
 #define CanonID_EOS_M50_Mark_II   (0x80000000ULL + 0x468ULL)
 
-// CanonID_EOS_D2000C after Canon's TIFF2CR2 convertor:
+// CanonID_EOS_D2000C after Canon's TIFF2CR2 converter:
 #define CanonID_EOS_D2000C        (0x80000000ULL + 0x520ULL)
-// CanonID_EOS_D6000C id after Canon's TIFF2CR2 convertor:
+// CanonID_EOS_D6000C id after Canon's TIFF2CR2 converter:
 #define CanonID_EOS_D6000C        (0x80000000ULL + 0x560ULL)
 
 #define OlyID_str2hex(str) ((unsigned long long)str[0]<<32 | str[1]<<24 | str[2]<<16 | str[3]<<8 | str[4])

--- a/samples/dcraw_emu.cpp
+++ b/samples/dcraw_emu.cpp
@@ -588,7 +588,7 @@ int main(int argc, char *argv[])
     timerstart();
     if (LIBRAW_SUCCESS != (ret = RawProcessor.dcraw_process()))
     {
-      fprintf(stderr, "Cannot do postpocessing on %s: %s\n", argv[arg],
+      fprintf(stderr, "Cannot do postprocessing on %s: %s\n", argv[arg],
               libraw_strerror(ret));
       if (LIBRAW_FATAL_ERROR(ret))
         continue;

--- a/samples/mem_image_sample.cpp
+++ b/samples/mem_image_sample.cpp
@@ -223,14 +223,14 @@ int main(int ac, char *av[])
     }
 
     // we should call dcraw_process before thumbnail extraction because for
-    // some cameras (i.e. Kodak ones) white balance for thumbnal should be set
+    // some cameras (i.e. Kodak ones) white balance for thumbnail should be set
     // from main image settings
 
     ret = RawProcessor.dcraw_process();
 
     if (LIBRAW_SUCCESS != ret)
     {
-      fprintf(stderr, "Cannot do postpocessing on %s: %s\n", av[i],
+      fprintf(stderr, "Cannot do postprocessing on %s: %s\n", av[i],
               libraw_strerror(ret));
       if (LIBRAW_FATAL_ERROR(ret))
         continue;

--- a/samples/multirender_test.cpp
+++ b/samples/multirender_test.cpp
@@ -46,7 +46,7 @@ int process_once(LibRaw &RawProcessor, int half_mode, int camera_wb,
 
   if (LIBRAW_SUCCESS != ret)
   {
-    fprintf(stderr, "Cannot do postpocessing on %s: %s\n", fname,
+    fprintf(stderr, "Cannot do postprocessing on %s: %s\n", fname,
             libraw_strerror(ret));
     return ret;
   }

--- a/samples/rawtextdump.cpp
+++ b/samples/rawtextdump.cpp
@@ -32,7 +32,7 @@ it under the terms of the one of two licenses as you choose:
 void usage(const char *av)
 {
 	printf(
-		"Dump (small) selecton of RAW file as tab-separated text file\n"
+		"Dump (small) selection of RAW file as tab-separated text file\n"
 		"Usage: %s inputfile COL ROW [CHANNEL] [width] [height]\n"
 		"  COL - start column\n"
 		"  ROW - start row\n"

--- a/samples/simple_dcraw.cpp
+++ b/samples/simple_dcraw.cpp
@@ -167,7 +167,7 @@ int main(int ac, char *av[])
 
     if (LIBRAW_SUCCESS != ret)
     {
-      fprintf(stderr, "Cannot do postpocessing on %s: %s\n", av[i],
+      fprintf(stderr, "Cannot do postprocessing on %s: %s\n", av[i],
               libraw_strerror(ret));
       if (LIBRAW_FATAL_ERROR(ret))
         continue;

--- a/src/demosaic/xtrans_demosaic.cpp
+++ b/src/demosaic/xtrans_demosaic.cpp
@@ -380,7 +380,7 @@ void LibRaw::xtrans_interpolate(int passes)
                                     homo[d][row][col]++;
                 }
 
-            /* Average the most homogenous pixels for the final result:	*/
+            /* Average the most homogeneous pixels for the final result:	*/
             if (height - top < LIBRAW_AHD_TILE + 4)
                 mrow = height - top + 2;
             if (width - left < LIBRAW_AHD_TILE + 4)

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -1192,7 +1192,7 @@ dng_skip:
   if ((maker_index != LIBRAW_CAMERAMAKER_Unknown) && normalized_model[0])
     SetStandardIlluminants (maker_index, normalized_model);
 
-  // Clear erorneus fuji_width if not set through parse_fuji or for DNG
+  // Clear erroneous fuji_width if not set through parse_fuji or for DNG
   if (fuji_width && !dng_version &&
       !(imgdata.process_warnings & LIBRAW_WARN_PARSEFUJI_PROCESSED))
     fuji_width = 0;

--- a/src/postprocessing/postprocessing_aux.cpp
+++ b/src/postprocessing/postprocessing_aux.cpp
@@ -196,9 +196,9 @@ void LibRaw::wavelet_denoise()
 #pragma omp critical
     free(temp);
   } /* end omp parallel */
-  /* the following loops are hard to parallize, no idea yes,
+  /* the following loops are hard to parallelize, no idea yes,
    * problem is wlast which is carrying dependency
-   * second part should be easyer, but did not yet get it right.
+   * second part should be easier, but did not yet get it right.
    */
   if (filters && colors == 3)
   { /* pull G1 and G3 closer together */

--- a/src/postprocessing/postprocessing_ph.cpp
+++ b/src/postprocessing/postprocessing_ph.cpp
@@ -1,7 +1,7 @@
 /* -*- C++ -*-
  * Copyright 2019-2021 LibRaw LLC (info@libraw.org)
  *
- Placehoder functions to build LibRaw w/o postprocessing tools
+ Placeholder functions to build LibRaw w/o postprocessing tools
  
  LibRaw is free software; you can redistribute it and/or modify
  it under the terms of the one of two licenses as you choose:

--- a/src/preprocessing/preprocessing_ph.cpp
+++ b/src/preprocessing/preprocessing_ph.cpp
@@ -1,7 +1,7 @@
 /* -*- C++ -*-
  * Copyright 2019-2021 LibRaw LLC (info@libraw.org)
  *
- Placehoder functions to build LibRaw w/o postprocessing 
+ Placeholder functions to build LibRaw w/o postprocessing 
  and preprocessing calls
  
  LibRaw is free software; you can redistribute it and/or modify

--- a/src/write/write_ph.cpp
+++ b/src/write/write_ph.cpp
@@ -1,7 +1,7 @@
 /* -*- C++ -*-
  * Copyright 2019-2021 LibRaw LLC (info@libraw.org)
  *
- Placehoder functions to build LibRaw w/o postprocessing 
+ Placeholder functions to build LibRaw w/o postprocessing 
  and preprocessing calls
  
  LibRaw is free software; you can redistribute it and/or modify

--- a/src/x3f/x3f_utils_patched.cpp
+++ b/src/x3f/x3f_utils_patched.cpp
@@ -1977,7 +1977,7 @@ static void x3f_setup_camf_entries(x3f_camf_t *CAMF)
     entry[i].name_offset = *p4++;
     entry[i].value_offset = *p4++;
 
-    /* Compute adresses and sizes */
+    /* Compute addresses and sizes */
     entry[i].name_address = (char *)(p + entry[i].name_offset);
     entry[i].value_address = p + entry[i].value_offset;
     entry[i].name_size = entry[i].value_offset - entry[i].name_offset;


### PR DESCRIPTION
Fixed via `codespell -q 3 -S Changelog.txt -L fo,ist,iten,mmaped,nd,oly,optio,sav,smal,spred`