### PR TITLE
Fix stack buffer overflow in LibRaw::parseCR3

### DIFF
--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -708,7 +708,7 @@ void LibRaw::identify()
     short nesting = -1;
     short nTrack = -1;
     short TrackType;
-    char AtomNameStack[128];
+    char AtomNameStack[129];
     strcpy(make, "Canon");
 
     szAtomList = ifp->size();


### PR DESCRIPTION
This PR fixes stack buffer overflow in LibRaw::parseCR3 revealed by fuzzing:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38233 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=42108
The off by one happens in `AtomNameStack[(nesting + 1) * 4] = '\0';` when the `nesting` is `31` and it writes to `AtomNameStack[128]` meanwhile the buffer size is 128.
Since there is already
```cpp
  if (nesting > 31)
    return -14; // too deep nesting
```
few lines above, the patch increases the buffer size to 129. Another way to fix it is to decrease the max nesting to 30.