### PR TITLE
Fix out of bounds memory read in LibRaw::parseAdobePanoMakernote

### DIFF
--- a/src/metadata/adobepano.cpp
+++ b/src/metadata/adobepano.cpp
@@ -26,7 +26,7 @@ void LibRaw::parseAdobePanoMakernote()
   int truncated;
 
 #define CHECKSPACE(s)                                                          \
-  if (posPrivateMknBuf + (s) > PrivateMknLength)                               \
+  if (posPrivateMknBuf > PrivateMknLength - (s))                               \
   {                                                                            \
     free(PrivateMknBuf);                                                       \
     return;                                                                    \


### PR DESCRIPTION
This PR fixes out of bounds memory read in LibRaw::parseAdobePanoMakernote revealed by fuzzing FreeImage:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40636
If `posPrivateMknBuf` equals to `4294967294` an integer overflow happens in `CHECKSPACE` macro
```cpp
#define CHECKSPACE(s)                                                          \
  if (posPrivateMknBuf + (s) > PrivateMknLength)                               \
  {                                                                            \
    free(PrivateMknBuf);                                                       \
    return;                                                                    \
  }
```
and the check erroneously passes the verification.