### PR TITLE
Fixes Use-of-uninitialized-value in LibRaw::init_fuji_block

### DIFF
--- a/src/decoders/fuji_compressed.cpp
+++ b/src/decoders/fuji_compressed.cpp
@@ -1101,8 +1101,13 @@ void LibRaw::fuji_compressed_load_raw()
   raw_block_offsets = (INT64 *)malloc(sizeof(INT64) * libraw_internal_data.unpacker_data.fuji_total_blocks);
 
   libraw_internal_data.internal_data.input->seek(libraw_internal_data.unpacker_data.data_offset, SEEK_SET);
-  libraw_internal_data.internal_data.input->read(
-      block_sizes, 1, sizeof(unsigned) * libraw_internal_data.unpacker_data.fuji_total_blocks);
+  int sizesToRead = sizeof(unsigned) * libraw_internal_data.unpacker_data.fuji_total_blocks;
+  if (libraw_internal_data.internal_data.input->read(block_sizes, 1, sizesToRead) != sizesToRead)
+  {
+    free(block_sizes);
+    free(raw_block_offsets);
+    throw LIBRAW_EXCEPTION_IO_EOF;
+  }
 
   raw_offset = ((sizeof(unsigned) * libraw_internal_data.unpacker_data.fuji_total_blocks) + 0xF) & ~0xF;
 


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46244

The root cause is up in the stack. In this case the `unsigned *block_sizes` in the `LibRaw::fuji_compressed_load_raw` is allocated with memory for one `unsigned` integer.
Then it is initialized from the stream `libraw_internal_data.internal_data.input->read(block_sizes, 1, sizeof(unsigned) * libraw_internal_data.unpacker_data.fuji_total_blocks);`
However if the stream position is close to the end and there is no enough data to fill all buffer, some bytes are left uninitialized (with a memory garbage).