### PR TITLE
Fixes Use-of-uninitialized-value in LibRaw::parse_fuji_compressed_header

### DIFF
--- a/src/decoders/fuji_compressed.cpp
+++ b/src/decoders/fuji_compressed.cpp
@@ -1163,7 +1163,8 @@ void LibRaw::parse_fuji_compressed_header()
   uchar header[16];
 
   libraw_internal_data.internal_data.input->seek(libraw_internal_data.unpacker_data.data_offset, SEEK_SET);
-  libraw_internal_data.internal_data.input->read(header, 1, sizeof(header));
+  if (libraw_internal_data.internal_data.input->read(header, 1, sizeof(header)) != sizeof(header))
+    return;
 
   // read all header
   signature = sgetn(2, header);


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46224

The `uchar header[16];` in `LibRaw::parse_fuji_compressed_header` is not initialized (contains garbage) because the stream is eof.