### PR TITLE
Fixes Use-of-uninitialized-value in LibRaw::parse_sinar_ia

### DIFF
--- a/src/metadata/misc_parsers.cpp
+++ b/src/metadata/misc_parsers.cpp
@@ -377,6 +377,8 @@ void LibRaw::parse_sinar_ia()
   if (entries < 1 || entries > 8192)
     return;
   fseek(ifp, get4(), SEEK_SET);
+  if (ifp->eof())
+    return;
   while (entries--)
   {
     off = get4();


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46574

`fread(str, 8, 1, ifp);` in `LibRaw::parse_sinar_ia` fails to read to `char str[8]` because the `ifp` steam is already at the end of file. The uninitialized `str` buffer is used later in
```cpp
    str[7] = 0; // Ensure end of string
    if (!strcmp(str, "META"))
      meta_offset = off;
    if (!strcmp(str, "THUMB"))
      thumb_offset = off;
    if (!strcmp(str, "RAW0"))
      data_offset = off;
```