### PR TITLE
Fix various typos

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -19,7 +19,7 @@
  * DJI Mavic 3
  * Nikon Z9: standard compression formats only
 
- == Multiple (resultion) thumbnails support ==
+ == Multiple (resolution) thumbnails support ==
  
  * New imgdata.thumbs_list data item with data fields:
 
@@ -70,7 +70,7 @@
    RawSpeed-v3 support
 
    If file was processed (or tried to process) via RawSpeed-v3, these bits
-   are rised in imgdata.process_warnings:
+   are raised in imgdata.process_warnings:
     LIBRAW_WARN_RAWSPEED3_PROCESSED - processed via RawSpeed v3
     LIBRAW_WARN_RAWSPEED3_PROBLEM - not processed (due to exception in RawSpeed library)
     LIBRAW_WARN_RAWSPEED3_UNSUPPORTED - unsupported file
@@ -222,7 +222,7 @@
  * Camera format support:  Panasonic v6/12 bit
  * Compile-time raw size limits implemented:
     LIBRAW_MAX_NONDNG_RAW_FILE_SIZE - max file size for non-DNG files (default: 2GB - 1 byte)
-    LIBRAW_MAX_DNG_RAW_FILE_SIZE - max DNG file size limit (4GB-1 if compiled w/ DNG SDK, 2GB-1 overwise)
+    LIBRAW_MAX_DNG_RAW_FILE_SIZE - max DNG file size limit (4GB-1 if compiled w/ DNG SDK, 2GB-1 otherwise)
  
  * ACES output: color conversion changed to provide D65 white point
 
@@ -245,7 +245,7 @@
    apply this patch to RawSpeed: RawSpeed/rawspeed.samsung-decoder.patch
  * DCI-P3 and Rec 2020 output colorspaces
  * Eliminated multiple signed/unsigned mismatch warnings (reported by gcc11)
- * fixed possible 1-byte stack underrun while handling text tags with zero lengh
+ * fixed possible 1-byte stack underrun while handling text tags with zero length
  * XMP block size in CR3 files limited to 1MB
  * Preview block size in CR3 files limited to 100MB
  * Fixed wrong handling of linear DNG files created from Pentax out-of-camera 
@@ -722,7 +722,7 @@ vendors that are already known to LibRaw will not change.
 
  * Better makernotes parsing for many cameras
 
- * Better parsing of makernotes embeded into DNG files created by
+ * Better parsing of makernotes embedded into DNG files created by
    Adobe DNG Converter
 
  * New imgdata.params.raw_processing_options value: LIBRAW_PROCESSING_ZEROFILTERS_FOR_MONOCHROMETIFFS
@@ -759,7 +759,7 @@ vendors that are already known to LibRaw will not change.
       (note: incompatibility with previous versions, so default is not set).
     LIBRAW_PROCESSING_DNGSDK_ZEROCOPY - will not copy data from Adobe DNG SDK decoded buffer, but use it as is
 
-  * Swtiched from auto_ptr to unique_ptr, to get back define LIBRAW_USE_AUTOPTR
+  * Switched from auto_ptr to unique_ptr, to get back define LIBRAW_USE_AUTOPTR
 
   * dcraw_emu: it is now possible to create output filename in a more flexible manner, via -Z switch:
      -Z - will output to stdout
@@ -1133,7 +1133,7 @@ Other fixes:
 
  * Sony ARW2.3 decoder:
    - params.sony_arw2_hack removed, decoded data are always in 0...17k range (note the difference with dcraw!)
-   - Additional processing options for Sony lossy compression techincal analysis.
+   - Additional processing options for Sony lossy compression technical analysis.
 
  * Dcraw 9.26 imported (but some changes not approved because Libraw do it better) with some exceptions:
     - no Pentax K3-II frame selection code
@@ -1188,7 +1188,7 @@ Other fixes:
    * imported dcraw 1.461: fixed error in BlackLevelDim handling
    * Accurate work with pattern black-level (cblack[6+])
    * Support for Olympus E-M10 and Fujifilm X-T1
-   * Adjusted possbile maximum value for Sigma SD9 small raws
+   * Adjusted possible maximum value for Sigma SD9 small raws
 
 2014-01-27 Alex Tutubalin <lexa@lexa.ru>
    * dcraw 1.460:  Nikon D3300, Panasonic DMC-TZ61, Sony  ILCE-5000
@@ -1345,7 +1345,7 @@ Other fixes:
     old Sigma cameras (SD9, SD14, Polaroid x530). For modern Foveon cameras
     one may try to create ICC profile (not supplied).
 
-    TODO: thumbnail extraction, fast cancelation
+    TODO: thumbnail extraction, fast cancellation
 
     Old foveon_*_load_raw (from dcraw) code is used if compiled with
     LIBRAW_DEMOSAIC_PACK_GPL2
@@ -1453,7 +1453,7 @@ API changes:
 
 2012-04-05 Alex Tutubalin <lexa@lexa.ru>
         * Casio EX-Z500 support
-        * (possible) I/O exceptions on file open catched in open_datastream
+        * (possible) I/O exceptions on file open caught in open_datastream
         * Fixed possible read-after-buffer in Sony ARW2 decoder
         * Fixed mingw32 errors when compiling LibRaw_windows_datastream
         * Makefile.msvc: support of OpenMP and LCMS (uncomment to use)
@@ -1695,7 +1695,7 @@ API changes:
           call.
 
         * No filtering_mode parameter. Raw tone curve is applied
-          at unpack() stage; zero pixels removed on postprocesing stage.
+          at unpack() stage; zero pixels removed on postprocessing stage.
 
         * unprocessed_raw and 4colors samples are adjusted to use
           new RAW data storage layout.
@@ -1826,7 +1826,7 @@ API changes:
              - Banding suppression
              - High-frequency noise suppression
              - Green channel equalization
-          + New chromatic abberration correction.
+          + New chromatic aberration correction.
           All three methods are written by Emil Martinec for Raw Therapee.
           Adapted to LibRaw by Jacques Desmis
 
@@ -2052,7 +2052,7 @@ API changes:
                In some cases LibRaw and calling process have different
                memory managers, so free() of make_mem_image() data
                results to program crash (especially in Win32/VisualStudio
-               enviroment).
+               environment).
 
              * LibRaw::free() is now private instead of public (again).
 
@@ -2071,7 +2071,7 @@ API changes:
                + Debug print removed from fatal error handler.
 
                + Mmaped I/O for dcraw_emu sample is turned on via -E switch
-                 now (because old -B switch is used for settng cropbox).
+                 now (because old -B switch is used for setting cropbox).
 
            * all client code should be recompiled due to structures size change
 
@@ -2328,14 +2328,14 @@ API changes:
            * API changed: params.gamma_16bit field removed. Gamma curve is
              set via params.gamm[0]/gamm[1] values (see documentation and
              samples for details)
-           * LibRaw::identify() splitted to avoid MS VS2008 bug (too many
+           * LibRaw::identify() split to avoid MS VS2008 bug (too many
              nested blocks)
 
            * Samples: dcraw_emu and mem_image samples supports new dcraw
               16bit/gamma semantics:
                 -6: set 16 bit output
                 -4: set 16 bit output and linear gamma curve and no auto
-                   brighness
+                   brightness
            *  LibRaw 0.8.0-Beta1
 
 2009-04-28 Alex Tutubalin <lexa@lexa.ru>
@@ -2475,7 +2475,7 @@ API changes:
 
 2009-01-14 Alex Tutubalin <lexa@lexa.ru>
            * Black mask extraction supported for all files with bayer data
-            (one component per pixel). Black mask data not avaliable
+            (one component per pixel). Black mask data not available
             for multi-component data (Foveon, Canon sRAW, Sinar 4-shot,
             Kodak YCC/YRGB).
 
@@ -2618,7 +2618,7 @@ API changes:
               - new cameras (Canon 50D, Sony A900, Nikon D90 & P6000,
                 Panasonic LX3 FZ28)
               - new method of black point subtraction for Canon cameras,
-                preliminary banding supression.
+                preliminary banding suppression.
             * Stack memory usage lowered (some thread data moved to dynamic
             memory)
             * some patches for MSVC compatibility

--- a/doc/API-CXX.html
+++ b/doc/API-CXX.html
@@ -342,7 +342,7 @@
       decoder may work again.</p>
     <p><a name="COLOR"></a></p>
     <h4>int LibRaw::COLOR(int row, int col)</h4>
-    <p>This call returns pixel color (color component number) in bayer patter at
+    <p>This call returns pixel color (color component number) in bayer pattern at
       row,col. The returned value is in 0..3 range for 4-component Bayer (RGBG2,
       CMYG and so on) and in 0..2 range for 3-color data.</p>
     <p>Color indexes returned could be used as index in imgdata.idata.cdesc
@@ -350,7 +350,7 @@
     <p><a name="error_count"></a></p>
     <h4>int LibRaw::error_count()</h4>
     <p>This call returns count of non-fatal data errors (out of range, etc)
-      occured in unpack() stage.</p>
+      occurred in unpack() stage.</p>
     <p><a name="subtract_black"></a></p>
     <h4>int LibRaw::subtract_black()</h4>
     <p>This call will subtract black level values from RAW data (for suitable
@@ -533,7 +533,7 @@
     <p>One can set the null handler by passing NULL to set_dataerror_handler;
       then no notifier function will be called. The same effect can be achieved
       by creating a LibRaw object with the LIBRAW_OPTIONS_NO_DATAERR_CALLBACK
-      flag in the contructor.</p>
+      flag in the constructor.</p>
     <p>In the case of error in the input data, processing of the current file is
       terminated and a notifier is called; all allocated resources are freed,
       and <a href="#recycle">recycle()</a> is performed. The current call will
@@ -663,7 +663,7 @@
         image_width*(bit_per_pixel/8)*image_colors, but may be more if you wish
         to align image rows to, for example, 8 or 16 or 32 bytes to make CPU
         more happy.</li>
-      <li>int bgr - pixel copy order. RGB if bgr==0 and BGR overwise.</li>
+      <li>int bgr - pixel copy order. RGB if bgr==0 and BGR otherwise.</li>
     </ul>
     <p>The function returns an integer number in accordance with the <a href="API-notes.html#errors">error
         code convention</a>: positive if any system call has returned an error,
@@ -780,7 +780,7 @@
         This call is not implemented for <a href="#buffer_datastream">LibRaw_buffer_datastream</a>,
         so external JPEG processing is not possible when buffer datastream used.
         <br>
-        This functon should be implemented in real input class, base class call
+        This function should be implemented in real input class, base class call
         always return error. <br>
         Working implementation sample can be found in <a href="#file_datastream">LibRaw_file_datastream</a>
         implementation in <strong>libraw/libraw_datastream.h</strong> file.</dd>
@@ -830,7 +830,7 @@
     </dl>
     <p>All other class methods are <a href="#datastream_methods">described
         above</a>.<br>
-      This class implements all possble methods, including fname() and
+      This class implements all possible methods, including fname() and
       subfile_open().</p>
     <p><a name="bigfile_datastream"></a></p>
     <h4>class LibRaw_bigfile_datastream - file input interface</h4>
@@ -850,7 +850,7 @@
       interface which is limited to 2Gb on many systems.</p>
     <p>All other class methods are <a href="#datastream_methods">described
         above</a>.<br>
-      This class implements all possble methods, including fname() and
+      This class implements all possible methods, including fname() and
       subfile_open().</p>
     <p><a name="buffer_datastream"></a></p>
     <h4>class LibRaw_buffer_datastream - memory buffer input interface</h4>

--- a/doc/API-datastruct.html
+++ b/doc/API-datastruct.html
@@ -712,7 +712,7 @@
         Don't use automatic increase of brightness by histogram.</dd>
       <dt><strong> float auto_bright_thr; </strong></dt>
       <dd><strong> dcraw keys: </strong> none <br>
-        Portion of clipped pixels when auto brigthness increase is used. Default
+        Portion of clipped pixels when auto brightness increase is used. Default
         value is 0.01 (1%) for dcraw compatibility. Recommended value for modern
         low-noise multimegapixel cameras depends on shooting style. Values in
         0.001-0.00003 range looks reasonable.</dd>

--- a/doc/API-notes.html
+++ b/doc/API-notes.html
@@ -66,7 +66,7 @@
           <dt><strong>Fatal errors</strong></dt>
           <dd>In the case of fatal errors (memory shortage, input data error,
             data unpacking failure), the current stage of processing is
-            terminated and all allocated resouces are freed.<br>
+            terminated and all allocated resources are freed.<br>
             If an attempt to continue processing is made, all subsequent API
             calls will return the LIBRAW_OUT_OF_ORDER_CALL error.<br>
             At the same time, the LibRaw instance in which a fatal error has
@@ -102,7 +102,7 @@
       When implementing own datastream classes, you need to take <strong>substream</strong>
       into account and pass control to methods of this field if it is active
       (not NULL).</p>
-    <p>If datastream implementaton knows name of input file, it should provide
+    <p>If datastream implementation knows name of input file, it should provide
       fname() call. This name will be used in <a href="API-CXX.html#callbacks">error
         callbacks</a> and in guessing name of JPEG file with metadata (for RAW
       files with external metadata).</p>
@@ -118,7 +118,7 @@
       LibRaw object) is not limited in any way (except by memory requirements).</p>
     <p>If a LibRaw object is created in one execution thread and used in
       another, external synchronization is necessary.</p>
-    <p>There is two libraries under Unix enviroment (Linux/FreeBSD/MacOS):
+    <p>There is two libraries under Unix environment (Linux/FreeBSD/MacOS):
       libraw_r.a (thread-safe) and libraw.a (single-threaded, slightly faster).</p>
     <p>Thread-safe library version stores intermediate unpacker data into LibRaw
       class data. So, several copies of LibRaw, working in parallel, is
@@ -221,7 +221,7 @@
         floating-point data.</li>
     </ul>
     <p>The buffer for RAW data is allocated by <a href="API-CXX.html#unpack">unpack()</a>
-      call and freeed upon calling <a href="API-CXX.html#recycle">recycle()</a>.</p>
+      call and freed upon calling <a href="API-CXX.html#recycle">recycle()</a>.</p>
     <p><a name="memimage"></a></p>
     <h4>Memory for the Postprocessed Image</h4>
     <p>On postprocessing stage each pixel contains four 16-bit values, one for
@@ -269,7 +269,7 @@
       memory is freed before the end of this call.</p>
     <p><a name="memunpack"></a></p>
     <h4>Unpacking into memory buffer</h4>
-    <p>Functons <a href="API-CXX.html#dcraw_make_mem_image">dcraw_make_mem_image()</a>
+    <p>Functions <a href="API-CXX.html#dcraw_make_mem_image">dcraw_make_mem_image()</a>
       <a href="API-CXX.html#dcraw_make_mem_thumb">dcraw_make_mem_thumb()</a>
       (and complementary calls in C-API) allocates memory for entire output
       datasets (full RGB bitmap and thumbnail, respectively).To free allocated

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -1200,7 +1200,7 @@ dng_skip:
   if ((maker_index != LIBRAW_CAMERAMAKER_Unknown) && normalized_model[0])
     SetStandardIlluminants (maker_index, normalized_model);
 
-  // Clear errorneous fuji_width if not set through parse_fuji or for DNG
+  // Clear erroneous fuji_width if not set through parse_fuji or for DNG
   if (fuji_width && !dng_version &&
       !(imgdata.process_warnings & LIBRAW_WARN_PARSEFUJI_PROCESSED))
     fuji_width = 0;


### PR DESCRIPTION
Found via `codespell -q 3 -L definitiion,fo,ist,iten,mmaped,nd,oly,optio,sav,smal,spred`