### PR TITLE
LibRaw::parse_phase_one: Return early if fseek fails

### DIFF
--- a/src/metadata/mediumformat.cpp
+++ b/src/metadata/mediumformat.cpp
@@ -33,7 +33,8 @@ void LibRaw::parse_phase_one(int base)
   unsigned offset = get4();
   if (offset == 0xbad0bad)
     return;
-  fseek(ifp, offset + base, SEEK_SET);
+  if (fseek(ifp, offset + base, SEEK_SET) != 0)
+    return;
   entries = get4();
   if (entries > 8192)
     return; // too much??


### PR DESCRIPTION
This fixes a crash we're having when fed broken data when using our own LibRaw_abstract_datastream fseek implementation 

I think it's because we just fail out and return "NOPE" early when the requested fseek value is out of range while LibRaw_bigfile_datastream actually try to seek to that position and then return NOPE. 

So if you ask our LibRaw_abstract_datastream to read something after a failed seek it'll give you something while LibRaw_bigfile_datastream won't.

We could change our implemation of seek, but i think it's better for everyone if the LibRaw code just returns/fails if fseek failed.