### PR TITLE
Fix OM-1 in cameraList()

### DIFF
--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -842,7 +842,7 @@ static const char *static_camera_list[] = {
 	"Olympus XZ-1",
 	"Olympus XZ-2",
 	"Olympus XZ-10",
-	"OM Digital Solutions OM-1",
+	"Olympus OM-1",
 	"OmniVision 4688",
 	"OmniVision OV5647",
 	"OmniVision OV5648",


### PR DESCRIPTION
The normarized_make of OM-1 is "Olympus", but the manufacturer name in LibRaw::cameraList() is "OM Digital Solutions".