### PR TITLE
[0.19-stable] check for input buffer size on datastream::gets

### DIFF
--- a/src/libraw_datastream.cpp
+++ b/src/libraw_datastream.cpp
@@ -175,6 +175,7 @@ INT64 LibRaw_file_datastream::tell()
 
 char *LibRaw_file_datastream::gets(char *str, int sz)
 {
+  if(sz<1) return NULL;
   if (substream)
     return substream->gets(str, sz);
   LR_STREAM_CHK();
@@ -398,6 +399,7 @@ INT64 LibRaw_buffer_datastream::tell()
 
 char *LibRaw_buffer_datastream::gets(char *s, int sz)
 {
+  if(sz<1) return NULL;
   if (substream)
     return substream->gets(s, sz);
   unsigned char *psrc, *pdest, *str;
@@ -594,6 +596,7 @@ INT64 LibRaw_bigfile_datastream::tell()
 
 char *LibRaw_bigfile_datastream::gets(char *str, int sz)
 {
+  if(sz<1) return NULL;
   LR_BF_CHK();
   return substream ? substream->gets(str, sz) : fgets(str, sz, f);
 }


### PR DESCRIPTION
(backported from commit fa329f37dca4a2c938f8abb50ee4a7ef93e64fbb)

----

This is my attempt to backport the fix for [CVE-2021-32142](https://github.com/LibRaw/LibRaw/issues/400) to the old `0.19-stable` branch, based on the fix that's already in the `0.20-stable` branch.

I am aware that this branch is too old and isn't receiving much (any?) maintenance.  However, I find myself in a situation where I must fix this downstream, and I can't rebase LibRaw to a newer branch because of ABI / soname changes.  So, instead of keeping it to myself, I thought that I would share it upstream, in case somebody else finds it useful.
