### PR TITLE
Remove hardcoded stdc++

### DIFF
--- a/libraw.pc.in
+++ b/libraw.pc.in
@@ -7,6 +7,6 @@ Name: libraw
 Description: Raw image decoder library (non-thread-safe)
 Requires: @PACKAGE_REQUIRES@
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
+Libs: -L${libdir} -lraw @PC_OPENMP@
 Libs.private: @PACKAGE_LIBS_PRIVATE@
 Cflags: -I${includedir}/libraw -I${includedir}

--- a/libraw_r.pc.in
+++ b/libraw_r.pc.in
@@ -7,6 +7,6 @@ Name: libraw
 Description: Raw image decoder library (thread-safe)
 Requires: @PACKAGE_REQUIRES@
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
+Libs: -L${libdir} -lraw_r @PC_OPENMP@
 Libs.private: @PACKAGE_LIBS_PRIVATE@
 Cflags: -I${includedir}/libraw -I${includedir}


### PR DESCRIPTION
The `libraw.pc` file hardcodes `-lstdc++` which is but unnecessary and breaks building dependents on clang.

```
lld: error: unable to find library -lstdc++
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

Example: https://github.com/r-windows/libs/actions/runs/6283365115/job/17063752821