### PR TITLE
Prioritize install instruction section

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,17 +9,17 @@ I. Installation steps
 
 2. Go to LibRaw folder and run ./configure and make:
 
+If you're using Github snapshot, create ./configure script:
+    autoreconf --install
+before using it (you'll need autotools installed).
+
  $ cd LibRaw-0.xx.yy
  $ ./configure  [...optional args...]
  $ make
 
 3. install by run make install as root:
- 
- $ sudo make install
 
-If you're using Github snapshot, create ./configure script:
-    autoreconf --install
-before using it (you'll need autotools installed).
+ $ sudo make install
 
 Alternatively, you may use pre-created Makefiles (Makefile.dist for Unix,
 Makefile.msvc for Windows/VisualStudio) and add/remove options by editing
@@ -38,7 +38,7 @@ II. ./configure options
 --enable-lcms
 --disable-lcms
 
-  Enable/disable LCMS color engine support. If enabled, ./configure will try to 
+  Enable/disable LCMS color engine support. If enabled, ./configure will try to
   find lcms library.  Both LCMS-1.x and LCMS-2.x are supported
   LCMS support is enabled by default
 
@@ -47,5 +47,3 @@ II. ./configure options
 --disable-examples
 
   Enables/disables examples compilation and installation. Enabled by default
-
-


### PR DESCRIPTION
higher above to better match a chronological ordering.

Also trimmed whitespace.

I cloned the GitHub repository, but did not have the `configure` script.

Could have better prevented these issues:

#290
#266
#182
#88

https://unix.stackexchange.com/a/18680/65319