### PR TITLE
fix the docs to properly reflect the size of cblack

### DIFF
--- a/doc/API-datastruct.html
+++ b/doc/API-datastruct.html
@@ -242,7 +242,7 @@
         black has been subtracted at the unpacking stage or by the camera
         itself), calculated at the unpacking stage, read from the RAW file, or
         hardcoded.</dd>
-      <dt><strong> unsigned cblack[4102]; </strong></dt>
+      <dt><strong> unsigned cblack[4104]; </strong></dt>
       <dd>Per-channel black level correction. First 4 values are per-channel
         correction, next two are black level pattern block size, than
         cblack[4]*cblack[5] correction values (for indexes


### PR DESCRIPTION
the size of cblack is LIBRAW_CBLACK_SIZE, which is defined in libraw_const.h as 4104, however the documentation shows a size of 4102.

This fix corrects the documentation to reflect the true size of cblack