### PR TITLE
[feature] support android NDK 21

### DIFF
--- a/src/libraw_datastream.cpp
+++ b/src/libraw_datastream.cpp
@@ -556,6 +556,8 @@ int LibRaw_bigfile_datastream::seek(INT64 o, int whence)
 #else
   return fseek(f, (long)o, whence);
 #endif
+#elif (defined(__ANDROID__) && __ANDROID_API__ < 24)
+  return fseek(f, o, whence);
 #else
   return fseeko(f, o, whence);
 #endif
@@ -570,6 +572,8 @@ INT64 LibRaw_bigfile_datastream::tell()
 #else
   return ftell(f);
 #endif
+#elif (defined(__ANDROID__) && __ANDROID_API__ < 24)
+  return ftell(f);
 #else
   return ftello(f);
 #endif

--- a/src/utils/utils_libraw.cpp
+++ b/src/utils/utils_libraw.cpp
@@ -662,7 +662,7 @@ void LibRaw::free_omp_buffers(char** buffers, int buffer_count)
 
 void 	LibRaw::libraw_swab(void *arr, size_t len)
 {
-#ifdef LIBRAW_OWN_SWAB
+#if defined(LIBRAW_OWN_SWAB) || (defined(__ANDROID__) && __ANDROID_API__ < 28)
 	uint16_t *array = (uint16_t*)arr;
 	size_t bytes = len/2;
 	for(; bytes; --bytes)

--- a/src/utils/utils_libraw.cpp
+++ b/src/utils/utils_libraw.cpp
@@ -662,7 +662,7 @@ void LibRaw::free_omp_buffers(char** buffers, int buffer_count)
 
 void 	LibRaw::libraw_swab(void *arr, size_t len)
 {
-#if defined(LIBRAW_OWN_SWAB) || (defined(__ANDROID__) && __ANDROID_API__ < 28)
+#ifdef LIBRAW_OWN_SWAB
 	uint16_t *array = (uint16_t*)arr;
 	size_t bytes = len/2;
 	for(; bytes; --bytes)


### PR DESCRIPTION
fseeko and ftello is only support android ndk 24.https://stackoverflow.com/questions/55571842/android-error-use-of-undeclared-identifier-fseeko
swab is only support android ndk 28. https://stackoverflow.com/questions/54392471/swab-in-android-ndk
This change will not damage the current code. Only NDK 21 is supported.