### PR TITLE
Makefile.msvc has invalid indent

### DIFF
--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -167,14 +167,14 @@ $(DLL): $(DLL_OBJECTS)
 
 # LIBRARY BUILD
 $(LIBSTATIC): $(LIB_OBJECTS)
-        -del /f $(LIBSTATIC)
+	-del /f $(LIBSTATIC)
 	lib /OUT:$(LIBSTATIC) /LTCG $(LIB_OBJECTS)
 
 # clean
 clean:
 	-del $(LIBSTATIC) $(LIBDLL) lib\*.exp
 	-del $(LIB_OBJECTS) $(DLL_OBJECTS)
-        -del object\*.o
+	-del object\*.o
 	-del $(DLL) $(SAMPLES)
 
 # OBJ generation rules


### PR DESCRIPTION
I'm working on windows. I tried "make" it, but it failes:

```
❯ make -f Makefile.msvc
Makefile.msvc:170: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.
```

---

Thanks for this open source project, btw.