### PR TITLE
build: add handling of openmp library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,8 +77,8 @@ lib_libraw_r_a_CFLAGS = -pthread -w
 lib_libraw_la_SOURCES = $(lib_libraw_a_SOURCES)
 lib_libraw_r_la_SOURCES = $(lib_libraw_a_SOURCES)
 
-lib_libraw_la_LDFLAGS = -no-undefined -version-info $(LIBRAW_SHLIB_VER)
-lib_libraw_r_la_LDFLAGS = -no-undefined -version-info $(LIBRAW_SHLIB_VER)
+lib_libraw_la_LDFLAGS = -no-undefined -version-info $(LIBRAW_SHLIB_VER) @OPENMP_LIBS@
+lib_libraw_r_la_LDFLAGS = -no-undefined -version-info $(LIBRAW_SHLIB_VER) @OPENMP_LIBS@
 
 
 # Sample binaries

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,47 @@ if test x$openmp = xtrue ; then
 	],[
 		AC_MSG_WARN([OpenMP support cannot be enabled because your system doesn't support it.])		
 	])
+
+	SAVE_LDFLAGS="$LDFLAGS"
+	LDFLAGS="-nostdlib"
+
+	AC_MSG_CHECKING([whether OpenMP works without explicit -l])
+
+	AC_LINK_IFELSE(
+		[AC_LANG_PROGRAM([[#include <omp.h>]], [[omp_get_num_threads();]])],
+		[OPENMP_LIBS=""; AC_MSG_RESULT([yes])],	# -l not required if success
+		[
+			AC_MSG_RESULT([no])
+			AC_MSG_CHECKING([for OpenMP library])
+
+			# try -lomp (clang), -lgomp (gcc), -liomp5 (intel)
+			LDFLAGS="-nostdlib -lomp $SAVE_LDFLAGS"
+			AC_LINK_IFELSE(
+				[AC_LANG_PROGRAM([[#include <omp.h>]], [[omp_get_num_threads();]])],
+				[OPENMP_LIBS="-lomp"; AC_MSG_RESULT([found -lomp])],
+				[
+					LDFLAGS="-nostdlib -lgomp $SAVE_LDFLAGS"
+					AC_LINK_IFELSE(
+						[AC_LANG_PROGRAM([[#include <omp.h>]], [[omp_get_num_threads();]])],
+						[OPENMP_LIBS="-lgomp"; AC_MSG_RESULT([found -lgomp])],
+						[
+							LDFLAGS="-nostdlib -liomp5 $SAVE_LDFLAGS"
+							AC_LINK_IFELSE(
+								[AC_LANG_PROGRAM([[#include <omp.h>]], [[omp_get_num_threads();]])],
+								[OPENMP_LIBS="-liomp5"; AC_MSG_RESULT([found -liomp5])],
+								[AC_MSG_ERROR([No suitable OpenMP library found])]
+							)
+						]
+					)
+				]
+			)
+		]
+	)
+
+	LDFLAGS="$SAVE_LDFLAGS"
+
+	AC_SUBST([OPENMP_LIBS])
+
 fi
 
 # check for libjpeg v8


### PR DESCRIPTION
when called with "-fopenmp" and "-nostdlib", clang won't add "-lomp" automatically, while gcc always add "-lgomp". See below:

For gcc, "-lgomp" is added always:

```
  # echo 'int main() { return 0; }' | gcc -fopenmp -v -x c - 2>&1 | grep -- "-lgomp"
   /usr/libexec/gcc/x86_64-pc-linux-gnu/14/collect2 -plugin ... -lgomp -lgcc ...
  # echo 'int main() { return 0; }' | gcc -fopenmp -nostdlib -v -x c - 2>&1 | grep -- "-lgomp"
   /usr/libexec/gcc/x86_64-pc-linux-gnu/14/collect2 -plugin ... -lgomp
```

For clang, "-lomp" is not added when both "-fopenmp" and "-nostdlib" exist:

```
  # echo 'int main() { return 0; }' | clang -fopenmp -v -x c - 2>&1 | grep -- "-lomp"
   "/usr/bin/x86_64-pc-linux-gnu-ld.bfd" --hash-style=gnu ... -lomp -L/usr/lib/llvm/19/lib64 ...
  # echo 'int main() { return 0; }' | clang -fopenmp -nostdlib -v -x c - 2>&1 | grep -- "-lomp"
```

In case of libraw, command to build .so is:

`  clang++ -fPIC -DPIC -shared -nostdlib ... -fopenmp -Wl,-soname -Wl,libraw.so.23 -o lib/.libs/libraw.so.23.0.0`

So LDFLAGS "-lomp" is needed if compiler is clang and openmp is enabled.

Otherwise, libomp.so won't be defined in Dynamic Section as shown bellow:

```
  # LC_ALL=C objdump -x /usr/lib64/libraw.so
  ...
  Dynamic Section:
    NEEDED               libomp.so

  ...
```

cause package depends on libraw either failed to build or failed to start (if libraw is rebuild with clang and openmp enabled) with error(s) like below:

`  undefined symbol: __kmpc_xxx
`
as had been reported in:

https://bugs.gentoo.org/881311
https://bugs.gentoo.org/896220
https://bugs.gentoo.org/915833