### PR TITLE
Make sure the profile_length is the same size as the allocated memory.

### DIFF
--- a/src/utils/open.cpp
+++ b/src/utils/open.cpp
@@ -1263,15 +1263,16 @@ int LibRaw::open_datastream(LibRaw_abstract_datastream *stream)
     {
       if (C.profile)
         free(C.profile);
-	  INT64 profile_sz = MIN(INT64(C.profile_length), ID.input->size() - ID.profile_offset);
-	  if (profile_sz > 0LL && profile_sz < LIBRAW_MAX_PROFILE_SIZE_MB * 1024LL * 1024LL)
-	  {
+      INT64 profile_sz = MIN(INT64(C.profile_length), ID.input->size() - ID.profile_offset);
+      if (profile_sz > 0LL && profile_sz < LIBRAW_MAX_PROFILE_SIZE_MB * 1024LL * 1024LL)
+      {
         C.profile = calloc(size_t(profile_sz),1);
+        C.profile_length = UINT32(profile_sz);
         ID.input->seek(ID.profile_offset, SEEK_SET);
         ID.input->read(C.profile, size_t(profile_sz), 1);
-	  }
-	  else
-		  C.profile = NULL;
+      }
+      else
+        C.profile = NULL;
     }
 
     SET_PROC_FLAG(LIBRAW_PROGRESS_IDENTIFY);


### PR DESCRIPTION
This pull request fixes and issue where `profile_length` is not updated with the new size of the allocated memory. Without this patch this can result in out of bounds reads after the allocated memory when a client uses the old value of `profile_length`.