### PR TITLE
Rremove duplicated supported camera

### DIFF
--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -499,7 +499,6 @@ static const char *static_camera_list[] = {
 	"Kodak DCS420",
 	"Kodak DCS460",
 	"Kodak DCS460M",
-	"Kodak DCS460",
 	"Kodak DCS520C",
 	"Kodak DCS560C",
 	"Kodak DCS620C",


### PR DESCRIPTION
`Kodak DCS460` is duplicated. (L500 and L502)