### PR TITLE
Fix positions used for DCB demosaic color interpolation

### DIFF
--- a/src/demosaic/dcb_demosaic.cpp
+++ b/src/demosaic/dcb_demosaic.cpp
@@ -351,12 +351,12 @@ void LibRaw::dcb_color_full()
       f[2] = 1.0f /
              (float)(1.0 +
                      fabsf(chroma[indx + u - 1][c] - chroma[indx - u + 1][c]) +
-                     fabsf(chroma[indx + u - 1][c] - chroma[indx + w + 3][c]) +
+                     fabsf(chroma[indx + u - 1][c] - chroma[indx + w - 3][c]) +
                      fabsf(chroma[indx - u + 1][c] - chroma[indx + w - 3][c]));
       f[3] = 1.0f /
              (float)(1.0 +
                      fabsf(chroma[indx + u + 1][c] - chroma[indx - u - 1][c]) +
-                     fabsf(chroma[indx + u + 1][c] - chroma[indx + w - 3][c]) +
+                     fabsf(chroma[indx + u + 1][c] - chroma[indx + w + 3][c]) +
                      fabsf(chroma[indx - u - 1][c] - chroma[indx + w + 3][c]));
       g[0] = 1.325f * chroma[indx - u - 1][c] - 0.175f * chroma[indx - w - 3][c] -
              0.075f * chroma[indx - w - 1][c] - 0.075f * chroma[indx - u - 3][c];


### PR DESCRIPTION
The positions used for the color interpolation seem to be slightly wrong. `f` and `g` use the following locations:
(`X` is the current pixel, `O` marks used offsets)


###  **First `f` terms**

**`f[0]`**

```
O......
.......
..O....
...X...
....O..
.......
.......
```

**`f[1]`**

```
......O
.......
....O..
...X...
..O....
.......
.......
```

**`f[2]`**

```
.......
.......
....O..
...X...
..O....
.......
O.....O
```

**`f[3]`**

```
.......
.......
..O....
...X...
....O..
.......
O.....O
```

---

###  **First `g` terms**

**`g[0]`**

```
O.O....
.......
O.O....
...X...
.......
.......
.......
```

**`g[1]`**

```
....O.O
.......
....O.O
...X...
.......
.......
.......
```

**`g[2]`**

```
.......
.......
.......
...X...
O.O....
.......
O.O....
```

**`g[3]`**

```
.......
.......
.......
...X...
....O.O
.......
....O.O
```

---

I don't fully understand what the algorithm does, but the pattern suggests that `f` should be using diagonals and `g` should be using values in the same quadrant as 2/3 of the values used by the corresponding `f`. This PR changes two signs to make the pattern match