### PR TITLE
Update libraw_types.h to fix calling C++ files in external C

### DIFF
--- a/libraw/libraw_types.h
+++ b/libraw/libraw_types.h
@@ -89,8 +89,18 @@ extern "C"
 #define NO_LCMS
 #endif
 
+#ifdef __cplusplus
+} /* extern C */
+#endif
+
+/* This cannot be in the extern C setting... */
 #include "libraw_const.h"
 #include "libraw_version.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 #ifdef _WIN32
   typedef __int64 INT64;


### PR DESCRIPTION
includes cannot be in extern C for the library to correctly compile under Swift Modules. This small change lets the compiler finish when compiling the library inside a module.