### PR TITLE
feat: Sony FX2 support

### DIFF
--- a/internal/libraw_cameraids.h
+++ b/internal/libraw_cameraids.h
@@ -342,4 +342,5 @@ it under the terms of the one of two licenses as you choose:
 #define SonyID_ILCE_7CM2        0x18dULL
 #define SonyID_ILX_LR1          0x18eULL
 #define SonyID_ZV_E10M2         0x18fULL
+#define SonyID_ILME_FX2         0x196ULL
 #endif

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -3089,6 +3089,31 @@ void LibRaw::identify_finetune_dcr(char head[64], INT64 fsize, INT64 flen)
             height = 2846;
           }
         }
+        else if (unique_id == SonyID_ILME_FX2)
+        {
+          if (raw_width == 7040 && raw_height == 4688) // Sony FX2 FF Uncompressed/Lossy
+          {
+            width = 7008;
+            height = 4672;
+          }
+          else if (raw_width == 7168 && raw_height == 5120) // Sony FX2 FF Lossless
+          {
+            width = 7008;
+            height = 4672;
+          }
+          else if (raw_width == 5120 && raw_height == 3584) // Sony FX2 Lossless/Medium
+          {
+            width = 4608;
+            height = 3072;
+          }
+          else if (raw_width == 3584 && raw_height == 2560) // Sony FX2 Lossless/Small
+          {
+            width = 3504;
+            height = 2336;
+          }
+          else
+            imgdata.process_warnings |= LIBRAW_WARN_VENDOR_CROP_SUGGESTED;
+        }
         else if(unique_id == SonyID_ILCE_1)
         {
           if (raw_width == 8704 && raw_height == 6144) // ILCE-1 FF@Compressed

--- a/src/metadata/sony.cpp
+++ b/src/metadata/sony.cpp
@@ -334,6 +334,8 @@ void LibRaw::setSonyBodyFeatures(unsigned long long id) {
        LIBRAW_SONY_Tag2010None, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff},
       {SonyID_ILME_FX3, sbfILCE_FF,
        LIBRAW_SONY_Tag2010None, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff},
+      {SonyID_ILME_FX2, sbfILCE_FF,
+       LIBRAW_SONY_Tag2010None, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff},
       {SonyID_ILCE_7RM3A, sbfILCE_FF,
        LIBRAW_SONY_Tag2010i, 0x0320, 0x019f, 0x024b, 0x024c, 0x0208},
       {SonyID_ILCE_7RM4A, sbfILCE_FF,
@@ -443,6 +445,7 @@ void LibRaw::setSonyBodyFeatures(unsigned long long id) {
       imSony.ImageCount3_offset = 0xffff; // not valid
     }
     break;
+  case SonyID_ILME_FX2:
   case SonyID_ZV_E1:
   case SonyID_ILCE_6700:
   case SonyID_ILCE_7CR:

--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -1290,6 +1290,7 @@ static const char *static_camera_list[] = {
 	"Sony ZV-E1",
 	"Sony ZV-E10",
 	"Sony ZV-E10 II",
+	"Sony ILME-FX2 (FX2)",
 	"STV680 VGA",
 	"PtGrey GRAS-50S5C",
 	"JaiPulnix BB-500CL",

--- a/src/tables/colordata.cpp
+++ b/src/tables/colordata.cpp
@@ -1800,6 +1800,8 @@ int LibRaw::adobe_coeff(unsigned make_idx, const char *t_model,
       { 6972, -2408,  -600, -4330, 12101,  2515,  -388,  1277,  5847 } },
     { LIBRAW_CAMERAMAKER_Sony, "ILME-FX3", 0, 0,
       { 6912, -2127, -469, -4470, 12175, 2587, -398, 1478, 6492 } },
+    { LIBRAW_CAMERAMAKER_Sony, "ILME-FX2", 0, 0,
+      { 7460, -2365, -588, -5687, 13442, 2474, -624, 1156, 6584 } },
 
     { LIBRAW_CAMERAMAKER_Sony, "ILX-LR1", 0, 0,
       { 8200, -2976, -719, -4296, 12053, 2532, -429, 1282, 5774 } }, // temp, same as for ILCE-7RM5


### PR DESCRIPTION
Recreating this PR with updates because I was provided with example files (which have been uploaded to https://raw.pixls.us/). The original PR was https://github.com/LibRaw/LibRaw/pull/715.

colordata values taken from Adobe's DCP profiles.