### PR TITLE
Fix several year-2038-problems

### DIFF
--- a/src/metadata/ciff.cpp
+++ b/src/metadata/ciff.cpp
@@ -397,7 +397,7 @@ void LibRaw::parse_ciff(INT64 offset, int length, int depth)
     }
     else if (type == 0x580e)
     {
-      timestamp = len;
+      timestamp = (unsigned)len;
     }
     else if (type == 0x180e)
     {

--- a/src/preprocessing/ext_preprocess.cpp
+++ b/src/preprocessing/ext_preprocess.cpp
@@ -26,7 +26,8 @@ void LibRaw::bad_pixels(const char *cfname)
 {
   FILE *fp = NULL;
   char *cp, line[128];
-  int time, row, col, r, c, rad, tot, n;
+  int row, col, r, c, rad, tot, n;
+  long long time;
 
   if (!filters)
     return;
@@ -43,7 +44,7 @@ void LibRaw::bad_pixels(const char *cfname)
     cp = strchr(line, '#');
     if (cp)
       *cp = 0;
-    if (sscanf(line, "%d %d %d", &col, &row, &time) != 3)
+    if (sscanf(line, "%d %d %lld", &col, &row, &time) != 3)
       continue;
     if ((unsigned)col >= width || (unsigned)row >= height)
       continue;

--- a/src/write/file_write.cpp
+++ b/src/write/file_write.cpp
@@ -195,10 +195,10 @@ void LibRaw::write_ppm_tiff()
 	{
 	    if(imgdata.params.output_flags & LIBRAW_OUTPUT_FLAGS_PPMMETA)
 	      fprintf(ofp,
-              "P7\n# EXPTIME=%0.5f\n# TIMESTAMP=%d\n# ISOSPEED=%d\n"
+              "P7\n# EXPTIME=%0.5f\n# TIMESTAMP=%lld\n# ISOSPEED=%d\n"
               "# APERTURE=%0.1f\n# FOCALLEN=%0.1f\n# MAKE=%s\n# MODEL=%s\n"
               "WIDTH %d\nHEIGHT %d\nDEPTH %d\nMAXVAL %d\nTUPLTYPE %s\nENDHDR\n",
-              shutter, (int)timestamp, (int)iso_speed,aperture, 
+              shutter, (long long int)timestamp, (int)iso_speed,aperture, 
 	      focal_len, make, model,
 	      width, height, colors, (1 << output_bps) - 1, cdesc);
 	    else
@@ -210,11 +210,11 @@ void LibRaw::write_ppm_tiff()
         else
 	{
 	    if(imgdata.params.output_flags & LIBRAW_OUTPUT_FLAGS_PPMMETA)
-	    	fprintf(ofp, "P%d\n# EXPTIME=%0.5f\n# TIMESTAMP=%d\n"
+	    	fprintf(ofp, "P%d\n# EXPTIME=%0.5f\n# TIMESTAMP=%lld\n"
 		"# ISOSPEED=%d\n# APERTURE=%0.1f\n# FOCALLEN=%0.1f\n"
 		"# MAKE=%s\n# MODEL=%s\n%d %d\n%d\n",
                 colors/2+5,
-		shutter, (int)timestamp, (int)iso_speed,aperture,focal_len,
+		shutter, (long long int)timestamp, (int)iso_speed,aperture,focal_len,
 		make,model,
 		width, height, (1 << output_bps)-1);
 	    else

--- a/src/x3f/x3f_parse_process.cpp
+++ b/src/x3f/x3f_parse_process.cpp
@@ -160,7 +160,7 @@ void LibRaw::parse_x3f()
         if (!strcmp(name, "WB_DESC"))
           strcpy(imgdata.color.model2, value);
         if (!strcmp(name, "TIME"))
-          imgdata.other.timestamp = atoi(value);
+          imgdata.other.timestamp = atoll(value);
         if (!strcmp(name, "SHUTTER"))
           imgdata.other.shutter = float(atof(value));
         if (!strcmp(name, "APERTURE"))


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Year_2038_problem

With this change, the ciff format supports timestamps between 1970 and 2106.

This patch was done while reviewing potential year-2038 issues in openSUSE.