### PR TITLE
Support Hasselblad X2D-II

### DIFF
--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -2799,6 +2799,13 @@ void LibRaw::identify_finetune_dcr(char head[64], INT64 fsize, INT64 flen)
 			top_margin = 92;
 			height = raw_height - top_margin;
         }
+        else if ((imHassy.SensorCode == 22) && imHassy.uncropped)
+        { // Hasselblad X2D II-100c (sensor code from makernotes)
+			left_margin = 124;
+			width = 11664;
+			top_margin = 92;
+			height = raw_height - top_margin;
+        }
 
 		if (tiff_samples > 1)
 		{

--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -468,6 +468,7 @@ static const char *static_camera_list[] = {
 	"Hasselblad X1D",
 	"Hasselblad X1D II 50C",
 	"Hasselblad X2D 100C",
+	"Hasselblad X2D II 100C",
 	"HTC UltraPixel",
 	"HTC MyTouch 4G",
 	"HTC One (A9)",


### PR DESCRIPTION
New SensorCode used to apply crop. It's the same sensor as X2D so the final size and matrix is the same as older model.

Here are the files: https://user.fm/files/v2-5d6b450aedbc837ba108d3859cbefed9/Hasselblad%20X2D-II.zip
I am not aware how to convert to FFF or if thats still something Hasselblad Phocus app does for new cameras. I only saw that I could convert to DNG with it. And the denoising mode outputs 3FRs.
I added some aspect ratio files, but seems like that Hasselblad parser doesn't handle different user crops.
