### PR TITLE
Support Sony ILCE-7M5

### DIFF
--- a/internal/libraw_cameraids.h
+++ b/internal/libraw_cameraids.h
@@ -344,4 +344,5 @@ it under the terms of the one of two licenses as you choose:
 #define SonyID_ZV_E10M2         0x18fULL
 #define SonyID_ILME_FX2         0x196ULL
 #define SonyID_ILCE_1M2         0x190ULL
+#define SonyID_ILCE_7M5         0x197ULL
 #endif

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -3139,7 +3139,7 @@ void LibRaw::identify_finetune_dcr(char head[64], INT64 fsize, INT64 flen)
 
 		  /* need samples for lossy small/medium w/ APC crop*/
         }
-        else if ((unique_id == SonyID_ILCE_7M4)|| (unique_id == SonyID_ILCE_7CM2) || (unique_id == SonyID_ILME_FX2))
+        else if ((unique_id == SonyID_ILCE_7M4) || (unique_id == SonyID_ILCE_7CM2) || (unique_id == SonyID_ILME_FX2) || (unique_id == SonyID_ILCE_7M5))
         {
           if (raw_width == 7168 && raw_height == 5120) 
           {

--- a/src/metadata/normalize_model.cpp
+++ b/src/metadata/normalize_model.cpp
@@ -399,6 +399,7 @@ void LibRaw::GetNormalizedModel()
       { SonyID_ILX_LR1,        "ILX-LR1"},
       { SonyID_ZV_E10M2,       "ZV-E10M2"},
       { SonyID_ILME_FX2,       "ILME-FX2"},
+      { SonyID_ILCE_7M5,       "ILCE-7M5"},
 };
 
   static const char *orig;

--- a/src/metadata/sony.cpp
+++ b/src/metadata/sony.cpp
@@ -364,6 +364,8 @@ void LibRaw::setSonyBodyFeatures(unsigned long long id) {
        LIBRAW_SONY_Tag2010None, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff},
       {SonyID_ZV_E10M2, sbfILCE_DX,
        LIBRAW_SONY_Tag2010None, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff},
+      {SonyID_ILCE_7M5, sbfILCE_FF,
+       LIBRAW_SONY_Tag2010None, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff},
   };
   ilm.CamID = id;
   int isPreProductionFW = 0;
@@ -454,6 +456,7 @@ void LibRaw::setSonyBodyFeatures(unsigned long long id) {
   case SonyID_ILCE_7CR:
   case SonyID_ILCE_7CM2:
   case SonyID_ILCE_9M3:
+  case SonyID_ILCE_7M5:
   case SonyID_ZV_E10M2:
     imSony.group9050 = LIBRAW_SONY_Tag9050d;
     break;
@@ -956,7 +959,7 @@ void LibRaw::process_Sony_0x9400(uchar *buf, ushort len, unsigned long long /*id
     FORC4 s[c] = SonySubstitution[buf[0x1a + c]];
     imSony.Sony0x9400_SequenceFileNumber = sget4(s);
 
-    imSony.Sony0x9400_SequenceLength2 = SonySubstitution[buf[0x1e]]; // files
+    imSony.Sony0x9400_SequenceLength2 = SonySubstitution[buf[0x1e]]; // files //ilce-7m5 modifed here
   }
 
   else if ((bufx == 0x0c) && (len >= 0x1f)) // 0x9400 'b' version

--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -1183,6 +1183,7 @@ static const char *static_camera_list[] = {
 	"Sony ILCE-7M2 (A7 II)",
 	"Sony ILCE-7M3 (A7 III)",
 	"Sony ILCE-7M4 (A7 IV)",
+	"Sony ILCE-7M5 (A7 V)",
 	"Sony ILCE-7C (A7C)",
 	"Sony ILCE-7CR (A7CR)",
 	"Sony ILCE-7CM2 (A7C II)",

--- a/src/tables/colordata.cpp
+++ b/src/tables/colordata.cpp
@@ -1770,7 +1770,9 @@ int LibRaw::adobe_coeff(unsigned make_idx, const char *t_model,
       { 7460,-2365,-588,-5687,13442,2474,-624,1156,6584 } },
     { LIBRAW_CAMERAMAKER_Sony, "ILCE-7C", 0, 0,
       { 7374,-2389,-551,-5435,13162,2519,-1006,1795,6552 } },
-
+	  
+    { LIBRAW_CAMERAMAKER_Sony, "ILCE-7M5", 0, 0,
+      { 9089, -3577, -787, -3563, 11326, 2557, -114, 928, 5904 } },
     { LIBRAW_CAMERAMAKER_Sony, "ILCE-7M4", 0, 0,
       { 7460,-2365,-588,-5687,13442,2474,-624,1156,6584 } },
     { LIBRAW_CAMERAMAKER_Sony, "ILCE-7M3", 0, 0,


### PR DESCRIPTION
The coefficients were obtained from Adobe DNG Converter; everything else works fine.

exif info from: https://exiftool.org/TagNames/Sony.html
Sample tests include HQLossyRAW: https://www.photographyblog.com/reviews/sony_a7_v_review#sample_images
I used my experimental ARW6 decoder to read the files.