### PR TITLE
Add a pre-commit config file to ensure formatting/linting guarantees regardless of the developer environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+# This file defines a collection of pre-commit hooks (https://pre-commit.com/).
+# To have this file executed, please install prek (https://pypi.org/project/prek/) and open a terminal in this folder
+# and run `prek install`. The first commit will install all the hooks, so please be patient.
+#
+# Apply to all files without committing:
+#   prek run --all-files
+# Update this file:
+#   prek autoupdate
+repos:
+-  repo: https://github.com/pre-commit/pre-commit-hooks
+   rev: v6.0.0
+   hooks:
+   -  id: fix-byte-order-marker
+   -  id: check-case-conflict
+   -  id: check-docstring-first
+   -  id: check-executables-have-shebangs
+   -  id: check-yaml
+   -  id: debug-statements
+   -  id: detect-private-key
+   -  id: trailing-whitespace
+   -  id: mixed-line-ending
+
+    # Linters
+-  repo: https://github.com/shellcheck-py/shellcheck-py
+   rev: v0.11.0.1
+   hooks:
+   -  id: shellcheck
+-  repo: https://github.com/checkmake/checkmake.git
+   rev: v0.3.2
+   hooks:
+       # Use this hook to let pre-commit build checkmake in its sandbox
+   -  id: checkmake
+    # Formatters
+-  repo: https://github.com/pocc/pre-commit-hooks
+   rev: v1.3.5
+   hooks:
+   -  id: clang-format
+      args: [-i]
+-  repo: https://github.com/perltidy/perltidy
+   rev: 20260204.06
+   hooks:
+   -  id: perltidy
+-  repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+   rev: v2.16.0
+   hooks:
+   -  id: pretty-format-yaml
+      args: [--autofix, --indent, '3']


### PR DESCRIPTION
Hi,

I noticed that while your repo has a .clang-format file, it seems that it is not being used by all developers. At my company I instated use of [pre-commit](https://pre-commit.com/) for all devs so that we could have uniform guarantees of formatting, linting, etc. regardless of the dev environment. As far as executing this, I recommend using [prek](https://pypi.org/project/prek/), as opposed to the original pre-commit (prek is much faster). You can install prek via pip with
```
python -m pip install prek
```
or through other package managers listed on the prek pypi page above. 

The next step is installing the pre-commit hook script in your git working copy (which will cause prek to be executed when you commit). To accomplish this, open a terminal window in your working copy folder and run
```
prek install 
```

I added various pre-commit hooks to this config file that I thought would be useful. There are, of course, a number of C++ linters available, but they require some configuration that I did not feel comfortable doing for someone else's project.

As a downstream user I would like to thank you for all of your hard work and I hope you receive this in the spirit in which it was given.

Best Regards,
Ty Cumby, Ph.D.