### PR TITLE
Clean up Sony A1 II model string

### DIFF
--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -1179,7 +1179,7 @@ static const char *static_camera_list[] = {
 	"SMaL Ultra-Pocket 4",
 	"SMaL Ultra-Pocket 5",
 	"Sony ILCE-1 (A1)",
-	"Sony ILCE-1M2 (A1 Mark II)",
+	"Sony ILCE-1M2 (A1 II)",
 	"Sony ILCE-7 (A7)",
 	"Sony ILCE-7M2 (A7 II)",
 	"Sony ILCE-7M3 (A7 III)",


### PR DESCRIPTION
Makes it consistent w/ other Sony models' nomenclature.

X-ref comment on https://github.com/LibRaw/LibRaw/commit/bdbc7b069610fd8652f04267ca74c5116593456d#diff-b2ab4f6aea549790f9193b7f5d59fe7ffa41a2ea2d95c8bee3c9e315d818e4df