### PR TITLE
Sony RX1RM3

### DIFF
--- a/internal/libraw_cameraids.h
+++ b/internal/libraw_cameraids.h
@@ -343,6 +343,7 @@ it under the terms of the one of two licenses as you choose:
 #define SonyID_ILCE_7CM2        0x18dULL
 #define SonyID_ILX_LR1          0x18eULL
 #define SonyID_ZV_E10M2         0x18fULL
+#define SonyID_DSC_RX1RM3       0x191ULL
 #define SonyID_ILME_FX2         0x196ULL
 #define SonyID_ILCE_1M2         0x190ULL
 #define SonyID_ILCE_7M5         0x197ULL

--- a/src/metadata/identify.cpp
+++ b/src/metadata/identify.cpp
@@ -3013,7 +3013,35 @@ void LibRaw::identify_finetune_dcr(char head[64], INT64 fsize, INT64 flen)
 
           }
         }
-		else if (raw_width == 3984) 
+        else if (unique_id == SonyID_DSC_RX1RM3)
+        {
+          if (raw_width == 9600) // FF, Uncompressed / Compressed
+          {
+            width -= 32;
+          }
+          else if (raw_width == 9728) // FF, Lossless compressed, L; same true readout as Uncompressed/Compressed
+          {
+            width = 9568;
+            height = 6376;
+          }
+          else if (raw_width == 7168) // FF, Lossless compressed, M
+          {
+            width = 6684;
+            height = 4460;
+          }
+          else if (raw_width == 5120) // FF, Lossless compressed, S
+          {
+            width = 4784;
+            height = 3188;
+          }
+          else
+          {
+            width = raw_width - 32; // fallback
+			imgdata.process_warnings |= LIBRAW_WARN_VENDOR_CROP_SUGGESTED;
+
+          }
+        }
+		else if (raw_width == 3984)
 		{ // Sony DSC-R1;
 			width = 3925;
 			order = 0x4d4d;

--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -1225,6 +1225,7 @@ static const char *static_camera_list[] = {
 	"Sony DSC-RX1",
 	"Sony DSC-RX1R",
 	"Sony DSC-RX1R II",
+	"Sony DSC-RX1R III",
 	"Sony DSC-RX10",
 	"Sony DSC-RX10 II",
 	"Sony DSC-RX10 III",

--- a/src/tables/colordata.cpp
+++ b/src/tables/colordata.cpp
@@ -1697,6 +1697,8 @@ int LibRaw::adobe_coeff(unsigned make_idx, const char *t_model,
     { LIBRAW_CAMERAMAKER_Sony, "DSC-RX10",0, 0, // same CMs: DSC-RX10, DSC-RX10M2, DSC-RX10M3
       { 6679,-1825,-745,-5047,13256,1953,-1580,2422,5183 } },
 
+    { LIBRAW_CAMERAMAKER_Sony, "DSC-RX1RM3", 0, 0,
+      { 9034,-3490,-777,-4004,11841,2448,-484,1352,5552 } },
     { LIBRAW_CAMERAMAKER_Sony, "DSC-RX1RM2", 0, 0,
       { 6629,-1900,-483,-4618,12349,2550,-622,1381,6514 } },
     { LIBRAW_CAMERAMAKER_Sony, "DSC-RX1R", 0, 0,


### PR DESCRIPTION
Added support for the Sony RXR1M3, specifically for the L, M, and S crop modes needed handling + color matrix. Currently, I am calculating these by cropping exactly at the edge of the visible area. However, since the RXR1M3 has unique M resolution, but the others are close enough to the ILCE-7RM5/  ILCE-7CR if cropped further. 

I wanted to clarify the cropping logic:

Should I strictly follow the visible area edge?
Must the output dimensions be multiples of a specific value (8, 16, 32)?
Does the logic vary depending on the specific camera model/mode?
Slightly based on the metadata?

https://user.fm/files/v2-3fa5286d612ee8ba08d376c2f754dd48/RX1R%20III%20Samples.zip


