### PR TITLE
Harden TIFF NewSubfileType parsing

### DIFF
--- a/libraw/libraw_internal.h
+++ b/libraw/libraw_internal.h
@@ -246,7 +246,7 @@ struct tiff_ifd_t
   int lineartable_len;
   libraw_dng_color_t dng_color[2];
   libraw_dng_levels_t dng_levels;
-  int newsubfiletype;
+  unsigned int newsubfiletype;
 };
 
 struct jhead

--- a/samples/newsubfiletype_regression.cpp
+++ b/samples/newsubfiletype_regression.cpp
@@ -1,0 +1,56 @@
+#define LIBRAW_LIBRARY_BUILD
+#include "../libraw/libraw.h"
+
+#include <cstdio>
+
+class NewSubfileTypeHarness : public LibRaw
+{
+public:
+  unsigned first_newsubfiletype() const { return tiff_ifd[0].newsubfiletype; }
+  unsigned ifd_count()
+  {
+    return get_internal_data_pointer()->identify_data.tiff_nifds;
+  }
+};
+
+static const unsigned char kNewSubfileTypePoc[] = {
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0xfe, 0x00, 0x04, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x00, 0xe3, 0x07, 0x1b,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+int main()
+{
+  NewSubfileTypeHarness raw;
+  const int rc = raw.open_buffer(kNewSubfileTypePoc, sizeof(kNewSubfileTypePoc));
+  if (rc != LIBRAW_SUCCESS && rc != LIBRAW_FILE_UNSUPPORTED)
+  {
+    std::fprintf(stderr, "open_buffer failed unexpectedly: %s (%d)\n",
+                 libraw_strerror(rc), rc);
+    return 1;
+  }
+
+  if (raw.ifd_count() == 0)
+  {
+    std::fprintf(stderr, "expected at least one TIFF IFD\n");
+    raw.recycle();
+    return 1;
+  }
+
+  if (raw.first_newsubfiletype() != 0xe3000001u)
+  {
+    std::fprintf(stderr,
+                 "expected newsubfiletype 0xe3000001, got 0x%08x\n",
+                 raw.first_newsubfiletype());
+    raw.recycle();
+    return 1;
+  }
+
+  raw.recycle();
+  return 0;
+}

--- a/src/metadata/tiff.cpp
+++ b/src/metadata/tiff.cpp
@@ -569,7 +569,7 @@ int LibRaw::parse_tiff_ifd(INT64 base)
       parse_tiff_ifd(base);
       break;
     case 0x00fe: /* NewSubfileType */
-      tiff_ifd[ifd].newsubfiletype = int(getreal(type));
+      tiff_ifd[ifd].newsubfiletype = get4();
       break;
     case 0x0100: /* 256, ImageWidth */
     case 0xf001: /* 61441, Fuji RAF RawImageFullWidth */


### PR DESCRIPTION
## Summary
- read TIFF tag `0x00fe` (NewSubfileType) with `get4()` instead of routing through `getreal()` and an out-of-range `int` cast
- store `tiff_ifd_t::newsubfiletype` as `unsigned int` so the file-controlled 32-bit value is preserved without signed narrowing
- add `samples/newsubfiletype_regression.cpp`, a focused regression using the exact 64-byte TIFF PoC shape from issue #844

## Verification
- `TMPDIR=$PWD/.tmp make -f Makefile.devel clean`
- `TMPDIR=$PWD/.tmp make -f Makefile.devel CC=gcc CXX=g++ lib/libraw.a CFLAGS='-DLIBRAW_USE_AUTOPTR -g -I. -pedantic -Wno-long-long -Wno-overflow -O1 -Wall -fsanitize=address,undefined,float-cast-overflow -fno-sanitize-recover=all -fno-omit-frame-pointer -DUSE_ZLIB' LDADD='-lz -fsanitize=address,undefined,float-cast-overflow'`
- `TMPDIR=$PWD/.tmp g++ -DLIBRAW_NOTHREADS -g -I. -pedantic -Wno-long-long -Wno-overflow -O1 -Wall -fsanitize=address,undefined,float-cast-overflow -fno-sanitize-recover=all -fno-omit-frame-pointer samples/newsubfiletype_regression.cpp -L./lib -lraw -lz -lm -fsanitize=address,undefined,float-cast-overflow -o bin/newsubfiletype_regression`
- `ASAN_OPTIONS=handle_sigill=1:print_stacktrace=1 ./bin/newsubfiletype_regression`

## Issue
- closes #844

## AI usage disclosure
- AI assistance was used to help draft and iterate on this patch. I manually reviewed the affected code, reproduced the sanitizer failure, and verified the final change locally.
