### PR TITLE
Add support for Canon PowerShot V1

### DIFF
--- a/src/metadata/canon.cpp
+++ b/src/metadata/canon.cpp
@@ -1310,16 +1310,31 @@ void LibRaw::parseCanonMakernotes(unsigned tag, unsigned type, unsigned len, uns
 
     case 3973: // R3; ColorDataSubVer: 34
     case 3778: // R6 Mark II, R7, R8, R10, R50, R50 V; ColorDataSubVer: 48
+               // PowerShot V1; ColorDataSubVer: 65
       imCanon.ColorDataVer = 11;
       AsShot_Auto_MeasuredWB(0x0069);
 
-      fseek(ifp, save1 + ((0x0069+0x0064) << 1), SEEK_SET);
-      Canon_WBpresets(2, 12);
-      fseek(ifp, save1 + ((0x0069+0x00c3) << 1), SEEK_SET);
-      Canon_WBCTpresets(0);
-      offsetChannelBlackLevel2 = save1 + ((0x0069+0x0102) << 1);
-      offsetChannelBlackLevel  = save1 + ((0x0069+0x0213) << 1);
-      offsetWhiteLevels        = save1 + ((0x0069+0x0217) << 1);
+      if (imCanon.ColorDataSubVer == 65) // PowerShot V1: same layout as ColorDataSubVer 64
+      {
+        imCanon.ColorDataVer = 12;
+        fseek(ifp, save1 + ((0x006d+0x0001) << 1), SEEK_SET);
+        Canon_WBpresets(2, 12);
+        fseek(ifp, save1 + ((0x0069+0x00d7) << 1), SEEK_SET);
+        Canon_WBCTpresets(0);
+        offsetChannelBlackLevel2 = save1 + ((0x0069+0x0116) << 1);
+        offsetChannelBlackLevel  = save1 + ((0x0069+0x0227) << 1);
+        offsetWhiteLevels        = save1 + ((0x0069+0x022b) << 1);
+      }
+      else
+      {
+        fseek(ifp, save1 + ((0x0069+0x0064) << 1), SEEK_SET);
+        Canon_WBpresets(2, 12);
+        fseek(ifp, save1 + ((0x0069+0x00c3) << 1), SEEK_SET);
+        Canon_WBCTpresets(0);
+        offsetChannelBlackLevel2 = save1 + ((0x0069+0x0102) << 1);
+        offsetChannelBlackLevel  = save1 + ((0x0069+0x0213) << 1);
+        offsetWhiteLevels        = save1 + ((0x0069+0x0217) << 1);
+      }
       break;
 
     case 4528: // R1, R5 Mark II; ColorDataSubVer: 64

--- a/src/tables/cameralist.cpp
+++ b/src/tables/cameralist.cpp
@@ -148,6 +148,7 @@ static const char *static_camera_list[] = {
 	"Canon PowerShot SX10 IS (CHDK hack)",
 	"Canon PowerShot SX20 IS (CHDK hack)",
 	"Canon PowerShot SX30 IS (CHDK hack)",
+	"Canon PowerShot V1",
 	"Canon EOS R",
 	"Canon EOS Ra",
 	"Canon EOS RP",

--- a/src/tables/colordata.cpp
+++ b/src/tables/colordata.cpp
@@ -357,6 +357,9 @@ int LibRaw::adobe_coeff(unsigned make_idx, const char *t_model,
 	{ LIBRAW_CAMERAMAKER_Canon, "PowerShot SX710 HS", 0, 0,
 	  { 13161,-5451,-1344,-1989,10654,1531,-47,1271,4955 } },
 
+  { LIBRAW_CAMERAMAKER_Canon, "PowerShot V1", 0, 0,
+    { 12600,-4747,-2027,-6110,15868,-29,110,479,6011 } },
+
 	{ LIBRAW_CAMERAMAKER_Canon, "PowerShot Pro1", 0, 0,
 	  { 10062,-3522,-1000,-7643,15117,2730,-765,817,7322 } },
 	{ LIBRAW_CAMERAMAKER_Canon, "PowerShot Pro70", 34, 0,


### PR DESCRIPTION
The PowerShot V1 writes ColorData with a new SubVer 65

Verified against PowerShot V1 RAW/C-RAW samples, from raw.pixls.us, and many others from my own PowerShot v1

Color matrix sourced from Adobe DNG Converter v18.6.0.2698 output (ColorMatrix2, D65), matching dnglab rawler database.

`
dev@ub24:~$ exiftool -ColorMatrix1 -ColorMatrix2 -CalibrationIlluminant1 -CalibrationIlluminant2 /mnt/e/AdobeDNGTest/output/IMG_0170.dng
Color Matrix 1                  : 1.8238 -1.0779 -0.187 -0.4784 1.4469 0.0174 0.0305 0.0058 0.9442
Color Matrix 2                  : 1.26 -0.4747 -0.2027 -0.611 1.5868 -0.0029 0.011 0.0479 0.6011
Calibration Illuminant 1        : Standard Light A
Calibration Illuminant 2        : D65
`