### PR TITLE
Fix buffer overflow in Kodak TextualInfo parsing

### DIFF
--- a/src/metadata/kodak.cpp
+++ b/src/metadata/kodak.cpp
@@ -168,7 +168,8 @@ void LibRaw::parse_kodak_ifd(INT64 base)
             {
               c++;
             }
-            strcpy(ilm.body, pkti + c);
+            strncpy(ilm.body, pkti + c, sizeof(ilm.body) - 1);
+            ilm.body[sizeof(ilm.body) - 1] = 0;
           }
           c = 5;
           if (((int)strlen(pkti) > c) && (!strncasecmp(pkti, "Lens:", c)))


### PR DESCRIPTION
## Summary

- Replace the unbounded Kodak `TextualInfo` copy with a bounded copy.
- Ensure `ilm.body` is always NUL-terminated when parsing `Camera body:` metadata.

Fixes #859

## Testing

- Performed a focused syntax/compile check of `src/metadata/kodak.cpp`.
- The change preserves the existing behavior for values that fit in `ilm.body` and safely truncates longer values.
- No new test fixture is added in this patch; the triggering and control inputs are attached to Issue #859.

## AI assistance disclosure

AI tools assisted with code review, drafting, and verification planning for this change. The human contributor reviewed the implementation, understands the affected code path, and takes responsibility for the patch.